### PR TITLE
Fix build error from missing interface in test

### DIFF
--- a/Hippo.Tests/Models/FakeAppRepository.cs
+++ b/Hippo.Tests/Models/FakeAppRepository.cs
@@ -23,6 +23,11 @@ namespace Hippo.Tests.Models
             };
         }
 
+        public void AddRelease(Application a, Release r)
+        {
+            throw new NotImplementedException();
+        }
+        
         public void Delete(Application a)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Build is broken on main because a test fake does not implement a new interface method.  This PR adds a stub for the missing method.