### PR TITLE
remove unused field from AppController

### DIFF
--- a/Hippo.Tests/Controllers/AppControllerTest.cs
+++ b/Hippo.Tests/Controllers/AppControllerTest.cs
@@ -41,15 +41,13 @@ namespace Hippo.Tests.Controllers
             .ReturnsAsync(admin);
             store.Setup(x => x.FindByIdAsync("2", CancellationToken.None))
             .ReturnsAsync(user);
-            var environment = new Mock<IWebHostEnvironment>();
-            environment.Setup(x => x.ContentRootPath).Returns("/etc");
             var options = new DbContextOptionsBuilder<DataContext>()
                 .UseInMemoryDatabase(databaseName: "Hippo")
                 .Options;
             var context = new DataContext(options);
             var userManager = new UserManager<Account>(store.Object, null, null, null, null, null, null, null, null);
             var jobScheduler = new FakeJobScheduler();
-            controller = new AppController(new DbUnitOfWork(context, new FakeCurrentUser(admin.UserName)), userManager, environment.Object, jobScheduler);
+            controller = new AppController(new DbUnitOfWork(context, new FakeCurrentUser(admin.UserName)), userManager, jobScheduler);
         }
 
         [Fact]
@@ -76,7 +74,7 @@ namespace Hippo.Tests.Controllers
 
         public FakeCurrentUser(string name)
         {
-            _name = name;    
+            _name = name;
         }
 
         public string Name() => _name;

--- a/Hippo/Controllers/AppController.cs
+++ b/Hippo/Controllers/AppController.cs
@@ -24,14 +24,12 @@ namespace Hippo.Controllers
     {
         private readonly IUnitOfWork unitOfWork;
         private readonly UserManager<Account> userManager;
-        private readonly IWebHostEnvironment environment;
         private readonly IJobScheduler scheduler;
 
-        public AppController(IUnitOfWork unitOfWork, UserManager<Account> userManager, IWebHostEnvironment environment, IJobScheduler scheduler)
+        public AppController(IUnitOfWork unitOfWork, UserManager<Account> userManager, IJobScheduler scheduler)
         {
             this.unitOfWork = unitOfWork;
             this.userManager = userManager;
-            this.environment = environment;
             this.scheduler = scheduler;
         }
 


### PR DESCRIPTION
Unused; `/etc` is hardcoded at this time in the `SystemdJobScheduler`.

At some point we could change the SystemdJobScheduler's constructor to accept a root directory, but that still would mean this code is dead; that logic would be handled in Startup.cs