### PR TITLE
Register revision

### DIFF
--- a/Hippo/Models/Application.cs
+++ b/Hippo/Models/Application.cs
@@ -37,17 +37,25 @@ namespace Hippo.Models
         [Required]
         public virtual ICollection<Channel> Channels { get; set; }
 
-        public void ReevaluateActiveRevisions()
+        public IReadOnlyList<Channel> ReevaluateActiveRevisions()
+        {
+            return ReevaluateActiveRevisionsLazy().ToList().AsReadOnly();
+        }
+
+        public IEnumerable<Channel> ReevaluateActiveRevisionsLazy()
         {
             if (Channels == null)
             {
-                return;
+                yield break;
             }
             foreach (var channel in Channels)
             {
-                channel.ReevaluateActiveRevision();
-                // TODO: should this trigger a redeploy?
+                if (channel.ReevaluateActiveRevision())
+                {
+                    yield return channel;
+                }
             }
+            // TODO: should this trigger a redeploy?
         }
     }
 }

--- a/Hippo/Models/Channel.cs
+++ b/Hippo/Models/Channel.cs
@@ -30,8 +30,10 @@ namespace Hippo.Models
         public uint PortID { get; set; }
         public Configuration Configuration { get; set; }
 
-        public void ReevaluateActiveRevision()
+        public bool ReevaluateActiveRevision()
         {
+            var previous = ActiveRevision;
+
             switch (RevisionSelectionStrategy)
             {
                 case ChannelRevisionSelectionStrategy.UseSpecifiedRevision:
@@ -45,6 +47,8 @@ namespace Hippo.Models
 
             }
             // TODO: should this trigger a redeploy?
+
+            return ActiveRevision != previous;
         }
     }
 

--- a/Hippo/Models/DataSeeder.cs
+++ b/Hippo/Models/DataSeeder.cs
@@ -52,6 +52,11 @@ namespace Hippo.Models
                     new Revision { RevisionNumber = "1.2.0-rc3" },
                     new Revision { RevisionNumber = "1.2.0-rc4" },
                     new Revision { RevisionNumber = "2.0.0" },
+                    // The following revisions exist in the test server, but are not seeded
+                    // as registered so they can be used for rulesy channel upgrade testing:
+                    // 1.1.1, 1.1.3, 1.3.0, 2.0.1, 2.0.2, 2.1.0
+                    //
+                    // (Don't use 1.1.2. I messed it up.)
                 };
 
                 var applications = new List<Application>

--- a/Hippo/ViewModels/AppRegisterRevisionForm.cs
+++ b/Hippo/ViewModels/AppRegisterRevisionForm.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Hippo.Logging;
+using Hippo.Models;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Hippo.ViewModels
+{
+    public class AppRegisterRevisionForm: ITraceable
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [Display(Name = "Revision to register")]
+        public string RevisionNumber { get; set; }
+
+        public string FormatTrace() =>
+            $"{nameof(AppRegisterRevisionForm)}[id={Id}]";
+    }
+}

--- a/Hippo/Views/App/Details.cshtml
+++ b/Hippo/Views/App/Details.cshtml
@@ -22,6 +22,7 @@
     <div class="row btn-group">
         <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
         <a asp-action="Release" asp-route-id="@Model.Id" class="btn btn-secondary">Configure a Channel</a>
+        <a asp-action="RegisterRevision" asp-route-id="@Model.Id" class="btn btn-secondary">Register a Revision</a>
         <a asp-action="Index" class="btn btn-secondary">Back to List</a>
     </div>
 </div>

--- a/Hippo/Views/App/RegisterRevision.cshtml
+++ b/Hippo/Views/App/RegisterRevision.cshtml
@@ -1,0 +1,21 @@
+@model Hippo.ViewModels.AppRegisterRevisionForm
+
+<h2>Register a revision for an application</h2>
+
+<form asp-action="RegisterRevision">
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <input type="hidden" asp-for="Id" />
+    <div class="form-group">
+        <label asp-for="RevisionNumber" class="control-label"></label>
+        <input asp-for="RevisionNumber" asp-items="Model.Revisions" class="form-control" />
+        <span asp-validation-for="RevisionNumber" class="text-danger"></span>
+    </div>
+    <div class="form-group btn-group">
+        <input type="submit" value="Register" class="btn btn-primary" />
+        <a asp-action="Index" class="btn btn-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}


### PR DESCRIPTION
Adds a screen to register a revision of an application, i.e. one that exists on the Bindle server but is not yet known to Hippo.  There is basically no validation or error checking.  The new screen is linked from the Details screen.

This means we now have live updates for rules-based channels.  E.g. view the `1.1 Compatibility` channel on port 32770: you should see a greeting from 1.1.0.  Then register 1.1.1 (which is in Bindle), and refresh the app page.  You should see a greeting from 1.1.1.

~NOTE: This builds on the rulesy channels PR (#60) so includes those commits.  The only interesting commit in this one is the last one ("Basic register revision feature").  Once that is merged I will rebase: this will become a much more sensible size and I will undraft it at that point.~