### PR TITLE
remove NuGet.Versioning

### DIFF
--- a/Hippo/Hippo.csproj
+++ b/Hippo/Hippo.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
     <PackageReference Include="SemanticVersioning" Version="1.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
     <PackageReference Include="Tomlyn" Version="0.1.2" />


### PR DESCRIPTION
replaced with SemanticVersioning in #60.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>