### PR TITLE
Enable Swagger for APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,5 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+Hippo/Hippo.xml

--- a/Hippo/ApiControllers/.editorconfig
+++ b/Hippo/ApiControllers/.editorconfig
@@ -1,0 +1,4 @@
+
+# Require XML comments (Documentation option is enabled to allow for swagger generation) 
+[*.cs]
+dotnet_diagnostic.CS1591.severity = warning

--- a/Hippo/Hippo.csproj
+++ b/Hippo/Hippo.csproj
@@ -6,6 +6,20 @@
     <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>$(MSBuildProjectDirectory)\Hippo.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>$(MSBuildProjectDirectory)\Hippo.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="Hippo.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.5" />

--- a/Hippo/Messages/.editorconfig
+++ b/Hippo/Messages/.editorconfig
@@ -1,0 +1,3 @@
+# Require XML comments (Documentation option is enabled to allow for swagger generation) 
+[*.cs]
+dotnet_diagnostic.CS1591.severity = warning

--- a/Hippo/Messages/ApplicationMessage.cs
+++ b/Hippo/Messages/ApplicationMessage.cs
@@ -2,6 +2,9 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Hippo.Messages
 {
+    /// <summary>
+    /// Base class for Hippo Application API Messages.
+    /// </summary>
     public abstract class ApplicationMessage
     {
         /// <summary>

--- a/Hippo/Messages/ChannelMessage.cs
+++ b/Hippo/Messages/ChannelMessage.cs
@@ -4,7 +4,9 @@ using Hippo.Models;
 
 namespace Hippo.Messages
 {
-
+    /// <summary>
+    /// Base class for Hippo Channel API Messages.
+    /// </summary>
     public class ChannelMessage
     {
         /// <summary>

--- a/Hippo/Messages/RegisterRevisionRequest.cs
+++ b/Hippo/Messages/RegisterRevisionRequest.cs
@@ -4,15 +4,41 @@ using Hippo.Logging;
 
 namespace Hippo.Messages
 {
+
+    /// <summary>
+    /// Request body for Hippo Register Revision API.
+    /// </summary>
+
     public class RegisterRevisionRequest : ITraceable
     {
+        /// <summary>
+        /// The GUID of the Application which the revision belongs to.
+        /// </summary>
+        /// <example>4208d635-7618-4150-b8a8-bc3205e70e32</example>
         public Guid? AppId { get; set; }
 
+        /// <summary>
+        /// This is the ID in Bindle or whatever storage backend is used. It gets composed
+        /// with a revision ID to get a Bindle ID.
+        ///
+        /// For example, the Weather application might have the StorageId contoso/weather.
+        /// Revision 1.4.0 of the Weather application would then have the bindle id
+        /// contoso/weather/1.4.0
+        /// </summary>
+        /// <example>contoso/weather</example>
         public string AppStorageId { get; set; }
 
+        /// <summary>
+        /// The revision number for the new revision.
+        /// </summary>
+        /// <example>1.2.3</example>
         [Required]
         public string RevisionNumber { get; set; }
 
+        /// <summary>
+        /// ITraceable.FormatTrace implementation.
+        /// </summary>
+        /// <returns>Trace string</returns>
         public string FormatTrace()
             => $"{GetType().Name}[appid={AppId}, stgid={AppStorageId}, rev={RevisionNumber}]";
     }

--- a/Hippo/Startup.cs
+++ b/Hippo/Startup.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Hippo.Models;
 using Hippo.Repositories;
@@ -90,10 +92,35 @@ namespace Hippo
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "hippo", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "hippo API", Version = "v1" });
+                var filePath = Path.Combine(AppContext.BaseDirectory, "Hippo.xml");
+                if (File.Exists(filePath))
+                {
+                    c.IncludeXmlComments(filePath);
+                }
+                c.AddSecurityDefinition("http", new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    BearerFormat = "JWT",
+                    Scheme = "Bearer"
+                });
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "http" }
+                        },
+                        Array.Empty<string>()
+                    }
+                });
             });
             services.AddRouting(options => options.LowercaseUrls = true);
-            services.AddMvc();
+            services
+              .AddMvc()
+              .AddJsonOptions(
+                  options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter())
+              );
         }
 
         public void Configure(IApplicationBuilder app, IServiceProvider serviceProvider)


### PR DESCRIPTION
These changes will enable swagger generation and swagger UI for APIs at swagger/v1/swagger.json and swagger/index.html respectively.

This PR will generate warnings but these will go away once #67 is merged, if #90 has been merged then do not merge this change until after #67.