### PR TITLE
remove BOM requirement from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,7 @@ indent_style = space
 indent_style = space
 indent_size = 4
 insert_final_newline = true
-charset = utf-8-bom
+charset = utf-8
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning


### PR DESCRIPTION
.editorconfig has an entry forcing C# files to be encoded as utf8 with BOM, seems like:

1. We don't want this
2. VS Code ignores it and VS does not, so we end up with BOM in files that have been edited with VS.

This change _should_ resolve this.