### PR TITLE
Show which port/domain a channel is served on

### DIFF
--- a/Hippo/Controllers/AppController.cs
+++ b/Hippo/Controllers/AppController.cs
@@ -239,7 +239,7 @@ namespace Hippo.Controllers
                     Application = application,
                     Name = form.ChannelName,
                 };
-                
+
                 // TODO: in memory seems not to wire up FKs
                 application.Channels.Add(channel);
 

--- a/Hippo/Models/Channel.cs
+++ b/Hippo/Models/Channel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Globalization;
 using Hippo.Rules;
 
 namespace Hippo.Models
@@ -55,6 +56,12 @@ namespace Hippo.Models
                 return HealthStatus.Unhealthy("No active revision");
             }
             return HealthStatus.Healthy;
+        }
+
+        // TODO: this will change to the domain when we get the reverse proxy working
+        public string ServedOn()
+        {
+            return (PortID + EphemeralPortRange).ToString(CultureInfo.InvariantCulture) + (Domain == null ? "" : $" or {Domain.Name}");
         }
 
         public ICollection<EnvironmentVariable> GetEnvironmentVariables() =>

--- a/Hippo/Repositories/DbApplicationRepository.cs
+++ b/Hippo/Repositories/DbApplicationRepository.cs
@@ -23,23 +23,27 @@ namespace Hippo.Repositories
             _context.Applications
                     .Where(application => application.Owner.UserName == _owner.Name())
                     .Include(a => a.Channels)
+                        .ThenInclude(c => c.Domain)
                     .Include(a => a.Revisions);
 
         public IEnumerable<Application> ListApplicationsForAllUsers() =>
             _context.Applications
                     .Include(a => a.Channels)
+                        .ThenInclude(c => c.Domain)
                     .Include(a => a.Revisions);
 
         public IEnumerable<Application> ListApplicationsByStorageId(string storageId) =>
             _context.Applications
                     .Where(application => application.StorageId == storageId && application.Owner.UserName == _owner.Name())
                     .Include(a => a.Channels)
+                        .ThenInclude(c => c.Domain)
                     .Include(a => a.Revisions);
 
         public Application GetApplicationById(Guid id) =>
             _context.Applications
                     .Where(application => application.Id == id && application.Owner.UserName == _owner.Name())
                     .Include(a => a.Channels)
+                        .ThenInclude(c => c.Domain)
                     .Include(a => a.Revisions)
                     .SingleOrDefault();
 

--- a/Hippo/Views/App/Details.cshtml
+++ b/Hippo/Views/App/Details.cshtml
@@ -35,7 +35,7 @@
         <div class="card">
             @if (item.Status().Health == Hippo.Models.HealthLevel.Healthy)
             {
-            <span class="card-header badge bg-success">Healthy (on @item.ActiveRevision.RevisionNumber)</span>
+            <span class="card-header badge bg-success">Healthy (on @item.ActiveRevision.RevisionNumber) - served on @item.ServedOn()</span>
             }
             else
             {


### PR DESCRIPTION
This is somewhat interim as the reverse proxy and domain mapping stuff comes into shape - the port will disappear once that moves to an internal detail of the scheduler.  But for now it can be useful to see (cf #101).

This PR naughtily also sneaks in a fix for where the Domain backref was not being set up on the in memory database, and fixes an issue where new channels did not have names.