### PR TITLE
(#142) fix account menu appearing behind contents

### DIFF
--- a/Hippo/Views/Shared/_AppLayout.cshtml
+++ b/Hippo/Views/Shared/_AppLayout.cshtml
@@ -25,16 +25,6 @@
         </main>
         <partial name="_Footer" />
     </div>
-    <div class="wrapper">
-
-        <main class="main logged-out" id="main">
-            <div class="columns is-multiline">
-                <div class="column is-12">
-                    @RenderBody()
-                </div>
-            </div>
-        </main>
-    </div>
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="~/js/app.js"></script>

--- a/Hippo/Views/Shared/_Layout.cshtml
+++ b/Hippo/Views/Shared/_Layout.cshtml
@@ -11,46 +11,31 @@
     <link href="~/styles/hippo.css" rel="stylesheet" />
 </head>
 <body>
-  @if (User.Identity.IsAuthenticated) {
-    <partial name="_NavTopbar" />
+  <partial name="_NavTopbar" />
 
-    <div class="wrapper">
-      <main class="main no-app" id="main">
-        <partial name="_NavBreadcrumb" />
-        
-        <div class="level mt-2 mr-2 content-title">
-          <div class="level-left">
-            <div class="level-item">
-              <div class="title has-text-primary">
-                <span><text>@ViewBag.Title</text></span>
-              </div>
+  <div class="wrapper">
+    <main class="main no-app" id="main">
+      <partial name="_NavBreadcrumb" />
+      
+      <div class="level mt-2 mr-2 content-title">
+        <div class="level-left">
+          <div class="level-item">
+            <div class="title has-text-primary">
+              <span><text>@ViewBag.Title</text></span>
             </div>
           </div>
         </div>
-        
-        <div class="columns is-multiline">
-          <div class="column is-12">
-            @RenderBody()
-          </div>
+      </div>
+      
+      <div class="columns is-multiline">
+        <div class="column is-12">
+          @RenderBody()
         </div>
-        
-      </main>
-      <partial name="_Footer" />
-    </div>
-
-  } else {
-    
-    <div class="wrapper">
-
-      <main class="main logged-out" id="main">
-        <div class="columns is-multiline">
-          <div class="column is-12">
-            @RenderBody()
-          </div>
-        </div>
-      </main>
-    </div>
-  }
+      </div>
+      
+    </main>
+    <partial name="_Footer" />
+  </div>
   
   <script src="~/lib/jquery/dist/jquery.min.js"></script>
   <script src="~/lib/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/Hippo/assets/styles/hippo.scss
+++ b/Hippo/assets/styles/hippo.scss
@@ -94,13 +94,13 @@ body {
 
 .wrapper {
   position: relative;
-  min-height: 100vh;
+  min-height: calc(100vh - #{$navHeight});
   overflow: hidden;
 }
 
 .main {
-  padding: calc(#{$navHeight} * 0.925) 2rem 7em calc(#{$sidebarWidth} + 2rem);
-  min-height: calc(100vh - 96px);
+  padding: calc(#{$navHeight}) 2rem 7em calc(#{$sidebarWidth} + 2rem);
+  min-height: calc(100vh - 7em);
   transition: 0.2s all ease-out;
   overflow: hidden;
 
@@ -154,7 +154,7 @@ body {
   left: 0;
   width: 100%;
   height: $navHeight;
-  z-index: 20;
+  z-index: 1920;
 }
 
 .navbar {


### PR DESCRIPTION
Simple CSS change to fix issue #142.

<img width="232" alt="Screen Shot 2021-07-14 at 12 19 53 PM" src="https://user-images.githubusercontent.com/686194/125681146-bd82a7c4-8227-4e9d-82ba-627c57d39eed.png">


Signed-off-by: flynnduism <dev@ronan.design>