### PR TITLE
(#149) fix unheathy env status appearance

### DIFF
--- a/Hippo/Views/Shared/_NavSidebar.cshtml
+++ b/Hippo/Views/Shared/_NavSidebar.cshtml
@@ -26,12 +26,12 @@
                                 </span>
                             </section>
                         } else {
-                            <section class="app-state is-success has-background-error">
+                            <section class="app-state is-danger has-background-danger">
                                 <span class="icon-text has-text-white">
                                     <span class="icon">
                                         <i class="fa fa-times-circle"></i>
                                     </span>
-                                    <span>Healthy</span>
+                                    <span>Unhealthy</span>
                                 </span>
                             </section>
                         }


### PR DESCRIPTION
Small html change to make the error states visible. Addresses issue #149 

<img width="475" alt="Screen Shot 2021-07-14 at 12 23 15 PM" src="https://user-images.githubusercontent.com/686194/125681249-1851d85f-03b9-49db-b613-c8e2202b339a.png">

Signed-off-by: flynnduism <dev@ronan.design>