### PR TITLE
Revert "rename binary as hippo-server"

### DIFF
--- a/Hippo.Tests/ApiControllers/TestStartup.cs
+++ b/Hippo.Tests/ApiControllers/TestStartup.cs
@@ -34,7 +34,7 @@ namespace Hippo.Tests.ApiControllers
             {
                 cfg.User.RequireUniqueEmail = true;
             }).AddEntityFrameworkStores<DataContext>();
-            services.AddControllers().AddApplicationPart(Assembly.Load("hippo-server")).AddControllersAsServices();
+            services.AddControllers().AddApplicationPart(Assembly.Load("Hippo")).AddControllersAsServices();
 
             services.AddAuthentication().AddJwtBearer(
                 cfg => cfg.TokenValidationParameters = new TokenValidationParameters

--- a/Hippo/Hippo.csproj
+++ b/Hippo/Hippo.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>5</WarningLevel>
-    <TargetName>hippo-server</TargetName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Hippo/Properties/launchSettings.json
+++ b/Hippo/Properties/launchSettings.json
@@ -17,7 +17,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "hippo-server": {
+    "hippo": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,


### PR DESCRIPTION
Reverts deislabs/hippo#162 due to a few upstream bugs:

- https://github.com/dotnet/sdk/issues/11173
- https://github.com/dotnet/sdk/issues/2252

This is causing the following to fail because it is not looking up the value of `TargetName`:

```
><> dotnet run
Building...
The application to execute does not exist: '/home/bacongobbler/code/hippo/Hippo/bin/Debug/net5.0/Hippo.dll'.
```

The issue has been open for several years, so I would not expect there to be a fix any time soon. We'll have to find an alternative workaround.