### PR TITLE
Make sure that correct error is logged for missing wagi.exe

### DIFF
--- a/Hippo/Schedulers/WagiLocalJobScheduler.cs
+++ b/Hippo/Schedulers/WagiLocalJobScheduler.cs
@@ -106,7 +106,7 @@ namespace Hippo.Schedulers
             }
             catch (Win32Exception e)  // yes, even on Linux
             {
-                if (e.Message.Contains("No such file or directory", StringComparison.InvariantCultureIgnoreCase))
+                if (e.Message.Contains("No such file or directory", StringComparison.InvariantCultureIgnoreCase) || e.Message.Contains("The system cannot find the file specified", StringComparison.InvariantCultureIgnoreCase))
                 {
                     _logger.LogError($"Program '{wagiProgram}' not found: check system path or set {ENV_WAGI}");
                     return;


### PR DESCRIPTION
This change makes sure that the correct error message is logged when wagi.exe is not in PATH or does not exist on Windows.