### PR TITLE
[#160] fix the env form(s) to correctly show and hide things

### DIFF
--- a/Hippo/assets/js/app.js
+++ b/Hippo/assets/js/app.js
@@ -1,7 +1,7 @@
 jQuery(function () {
   // custom js for interactive elements in hippo
 
-  // application view environment show/hide tabs
+  // application view: environment show/hide tabs
   $('.tabs li:first-child a').addClass('is-active');
   $('.tab-pane').removeClass("is-active");
   $('.tab-pane:first').addClass('is-active');
@@ -16,51 +16,60 @@ jQuery(function () {
     return false;
   });
 
+  // app view: expand and collapse revision metadata
   $('.rev-item .fa').click(function(){
     $(this).toggleClass('fa-chevron-down');
     $(this).toggleClass('fa-chevron-up');
     $(this).next().toggle();
   });
 
-  // show/hide env vars form
-  $("#envVarToggle").bind("click", function() {
-    $("#envVars").toggleClass("hide");
-  });
 
-  // environment create/edit form
-  $.fn.deployReveal = function() {
-    if ($("input.env-radio").is(':checked')) {
-      // style the radio buttons accordingly
-      $(".env-deploy-label").removeClass("is-active");
-      $("input.env-radio:checked").parent("label").toggleClass("is-active");
-    }
-  };
-
-  // update radio button text labels
-  $.fn.radioLabels = function() {
+  // environment form: update labels
+  $.fn.rewordLabels = function() {
     $('input[value="UseRangeRule"]').next("p").html("<strong>Auto-deploy</strong> <small>Deploy versions as they are created.</small>");
     $('input[value="UseSpecifiedRevision"]').next("p").html("<strong>Selective deploy</strong> <small>Lock deployment to a specific version.</small>");
   }
 
-  // show form fields based on selection
-  $.fn.radioSelection = function() {
+  // environment form: enable fancy radio buttons
+  $.fn.deployLabels = function() {
+    if ($('input.env-radio').is(':checked')) {
+      // style the radio buttons accordingly
+      $('.env-deploy-label').removeClass('is-active');
+      $('input.env-radio:checked').parent('label').toggleClass('is-active');
+    } else {
+      // if nothing is selected, choose auto
+      $('input[name=SelectedRevisionSelectionStrategy][value="UseRangeRule"]').prop('checked',true);
+
+      $.fn.deployLabels();
+    }
+  };
+
+  // environment form: show deploy config based on radio buttons
+  $.fn.deploySelection = function() {
     if ($('input[value="UseRangeRule"]').is(':checked')) {
       $("#envManualField").addClass("hide");
-      $("#envAutoField").toggleClass("hide");
+      $("#envAutoField").removeClass("hide");
     };
     if ($('input[value="UseSpecifiedRevision"]').is(':checked')) {
       $("#envAutoField").addClass("hide");
-      $("#envManualField").toggleClass("hide");
+      $("#envManualField").removeClass("hide");
     };
   }
 
-  $.fn.radioLabels();
-  $.fn.deployReveal();
-  $.fn.radioSelection();
-
-  $('input.env-radio').change(function() {
-    $.fn.deployReveal();
-    $.fn.radioSelection();
-    return false;
+  // environment form: show/hide env vars
+  $("#envVarToggle").bind("click", function() {
+    $("#envVars").toggleClass("hide");
   });
+
+  if ($("input.env-radio").length > 0){
+    $.fn.rewordLabels();
+    $.fn.deployLabels();
+    $.fn.deploySelection();
+
+    $('input.env-radio').change(function() {
+      $.fn.deployLabels();
+      $.fn.deploySelection();
+      // return false;
+    })
+  };
 })

--- a/Hippo/assets/js/dist/app.dev.js
+++ b/Hippo/assets/js/dist/app.dev.js
@@ -2,7 +2,7 @@
 
 jQuery(function () {
   // custom js for interactive elements in hippo
-  // application view environment show/hide tabs
+  // application view: environment show/hide tabs
   $('.tabs li:first-child a').addClass('is-active');
   $('.tab-pane').removeClass("is-active");
   $('.tab-pane:first').addClass('is-active');
@@ -13,54 +13,63 @@ jQuery(function () {
     $(this).addClass('is-active');
     $("[asp-class=" + activeTab + "]").addClass('is-active');
     return false;
-  });
+  }); // app view: expand and collapse revision metadata
+
   $('.rev-item .fa').click(function () {
     $(this).toggleClass('fa-chevron-down');
     $(this).toggleClass('fa-chevron-up');
     $(this).next().toggle();
-  }); // show/hide env vars form
+  }); // environment form: update labels
 
-  $("#envVarToggle").bind("click", function () {
-    $("#envVars").toggleClass("hide");
-  }); // environment create/edit form
-
-  $.fn.deployReveal = function () {
-    if ($("input.env-radio").is(':checked')) {
-      // style the radio buttons accordingly
-      $(".env-deploy-label").removeClass("is-active");
-      $("input.env-radio:checked").parent("label").toggleClass("is-active");
-    }
-  }; // update radio button text labels
-
-
-  $.fn.radioLabels = function () {
+  $.fn.rewordLabels = function () {
     $('input[value="UseRangeRule"]').next("p").html("<strong>Auto-deploy</strong> <small>Deploy versions as they are created.</small>");
     $('input[value="UseSpecifiedRevision"]').next("p").html("<strong>Selective deploy</strong> <small>Lock deployment to a specific version.</small>");
-  }; // show form fields based on selection
+  }; // environment form: enable fancy radio buttons
 
 
-  $.fn.radioSelection = function () {
+  $.fn.deployLabels = function () {
+    if ($('input.env-radio').is(':checked')) {
+      // style the radio buttons accordingly
+      $('.env-deploy-label').removeClass('is-active');
+      $('input.env-radio:checked').parent('label').toggleClass('is-active');
+    } else {
+      // if nothing is selected, choose auto
+      $('input[name=SelectedRevisionSelectionStrategy][value="UseRangeRule"]').prop('checked', true);
+      $.fn.deployLabels();
+    }
+  }; // environment form: show deploy config based on radio buttons
+
+
+  $.fn.deploySelection = function () {
     if ($('input[value="UseRangeRule"]').is(':checked')) {
       $("#envManualField").addClass("hide");
-      $("#envAutoField").toggleClass("hide");
+      $("#envAutoField").removeClass("hide");
     }
 
     ;
 
     if ($('input[value="UseSpecifiedRevision"]').is(':checked')) {
       $("#envAutoField").addClass("hide");
-      $("#envManualField").toggleClass("hide");
+      $("#envManualField").removeClass("hide");
     }
 
     ;
-  };
+  }; // environment form: show/hide env vars
 
-  $.fn.radioLabels();
-  $.fn.deployReveal();
-  $.fn.radioSelection();
-  $('input.env-radio').change(function () {
-    $.fn.deployReveal();
-    $.fn.radioSelection();
-    return false;
+
+  $("#envVarToggle").bind("click", function () {
+    $("#envVars").toggleClass("hide");
   });
+
+  if ($("input.env-radio").length > 0) {
+    $.fn.rewordLabels();
+    $.fn.deployLabels();
+    $.fn.deploySelection();
+    $('input.env-radio').change(function () {
+      $.fn.deployLabels();
+      $.fn.deploySelection(); // return false;
+    });
+  }
+
+  ;
 });

--- a/Hippo/assets/styles/dist/hippo.css
+++ b/Hippo/assets/styles/dist/hippo.css
@@ -494,6 +494,10 @@ p.card-header-title {
   padding: 0.5rem 1.25rem;
   text-align: right;
 }
+.env-list .tabs li.tab .env-dropdown .dropdown-menu a.is-active {
+  background: transparent;
+  color: #3E3A55;
+}
 .env-list .tabs li.tab a.env-block.is-active {
   background: white;
   box-shadow: 0 0 3px 1px #BAB5DA;

--- a/Hippo/assets/styles/hippo.scss
+++ b/Hippo/assets/styles/hippo.scss
@@ -626,6 +626,11 @@ p.card-header-title {
           a {
             padding: 0.5rem 1.25rem;
             text-align: right;
+
+            &.is-active {
+              background: transparent;
+              color: $dark2;
+            }
           }
         }
       }


### PR DESCRIPTION
Changes to the *Configure Environment* form, to address the bug that impacts on showing the selected config around `SelectedRevisionSelectionStrategy` - these changes will fix issues #160 #198 #199.

* rewrites the JS that handles the show/hide logic
* fixes the bug that kept the Auto Deploy settings hidden (when editing an existing Env)
* if nothing is selected (such as in the New Environment flow), then the UI will show the first option as active; which is more in line with typical radio button behavior 

![Screen Shot 2021-08-11 at 2 18 19 PM](https://user-images.githubusercontent.com/686194/129105237-2b1c1389-9220-4361-8683-a227e455a33b.png)


---

Signed-off-by: flynnduism <dev@ronan.design>