### PR TITLE
Ignore formatting issues unless release build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>5</WarningLevel>
   </PropertyGroup>
+
+   <PropertyGroup Condition=" '$(Configuration)' != 'Release'">
+     <WarningsNotAsErrors>IDE0055</WarningsNotAsErrors>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change will prevent formatting issues from making dotnet build fail unless the configuration is release. 

In its current state this means that formatting errors will cause CI builds to fail on PR checks as we build release configurations there.