### PR TITLE
Exposes proxy port in UI

### DIFF
--- a/Hippo/Program.cs
+++ b/Hippo/Program.cs
@@ -64,7 +64,7 @@ namespace Hippo
             var proxyUrl = config?.GetValue<string>("Kestrel:Endpoints:Https:Url");
             if (!string.IsNullOrEmpty(proxyUrl) && Uri.TryCreate(proxyUrl, UriKind.Absolute, out Uri result))
             {
-                port = result.Port == 0 || result.Port == 443 ? "443" : result.Port.ToString(CultureInfo.InvariantCulture);
+                port = result.Port == 0 || result.Port == 443 ? string.Empty : $":{result.Port.ToString(CultureInfo.InvariantCulture)}";
             }
             return port;
         }

--- a/Hippo/Views/Shared/_NavSidebar.cshtml
+++ b/Hippo/Views/Shared/_NavSidebar.cshtml
@@ -43,7 +43,7 @@
                             @Html.DisplayFor(modelItem => item.Name)
                         </p>
                     </a>
-                    <a class="env-url" target="_blank" href="https://@item.Domain.Name:@Hippo.Program.ProxyPort">
+                    <a class="env-url" target="_blank" href="https://@item.Domain.Name@Hippo.Program.ProxyPort">
                         @Html.DisplayFor(modelItem => item.Domain.Name) <i class="fa fa-external-link"></i>
                     </a>
 


### PR DESCRIPTION
This is a temporary solution to the fact that we create a link to an app channel without the proxy port in the Hippo UI.

This is intended to be a good enough solution for v0.1.0 and will need re visiting when we ship external schedulers.

closes #140