### PR TITLE
update container definitions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,15 +10,15 @@ RUN su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${N
 WORKDIR /tmp
 
 # Install hippo
-ARG HIPPO_VERSION="v0.7.0"
+ARG HIPPO_VERSION="v0.9.0"
 RUN curl -fsSLo hippocli.tar.gz https://github.com/deislabs/hippo-cli/releases/download/${HIPPO_VERSION}/hippo-${HIPPO_VERSION}-linux-amd64.tar.gz && tar -xvf hippocli.tar.gz && mv hippo /usr/local/bin/  
 
 # Install bindle
-ARG BINDLE_VERSION="v0.4.1"
+ARG BINDLE_VERSION="v0.6.0"
 RUN curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server /usr/local/bin/  
 
 # Install WAGI
-ARG WAGI_VERSION="v0.3.0"
+ARG WAGI_VERSION="v0.4.0"
 RUN curl -fsSLo wagi.tar.gz https://github.com/deislabs/wagi/releases/download/${WAGI_VERSION}/wagi-${WAGI_VERSION}-linux-amd64.tar.gz  && tar -xvf wagi.tar.gz && mv wagi /usr/local/bin/ 
 
 # Install yo-wasm
@@ -27,8 +27,5 @@ RUN su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && npm install -g 
 # Install Rust 
 RUN su vscode -c "umask 0002 && cd /tmp && mkdir rust && cd rust && curl -fsSLo install_rust.sh https://sh.rustup.rs && chmod +x ./install_rust.sh  && ./install_rust.sh -y -t wasm32-wasi"
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends gcc gcc-multilib
-
-# TODO remove this before release as it is temporary. The hippo enabled yo wasm package is not published yet so we need to use the one from the repo.
-RUN su vscode -c ". /usr/local/share/nvm/nvm.sh && npm uninstall -g generator-wasm && mkdir yowasm && cd yowasm && curl -fsSLo ./yowasm.tar.gz https://github.com/deislabs/yo-wasm/releases/download/v0.0.4%2Bpreview2/generator-wasm-0.0.3.tgz && npm install -g ./yowasm.tar.gz && cd - && rm -r yowasm"
 
 WORKDIR /

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 // It should match the value of the ENV VAR DEVCONTAINER_VERSION in build-devcontainer.yml
 {
     "name": "Hippo",
-    "image": "ghcr.io/deislabs/hippo-dev:v1.0.0",
+    "image": "ghcr.io/deislabs/hippo-dev:v1.0.1",
     // Set *default* container specific settings.json values on container create.
     "settings": {
         "remote.autoForwardPorts": false

--- a/.github/release-image/Dockerfile
+++ b/.github/release-image/Dockerfile
@@ -39,11 +39,11 @@ ARG HIPPO_CLI_VERSION="v0.9.0"
 RUN mkdir hippocli && cd hippocli && curl -fsSLo hippocli.tar.gz https://github.com/deislabs/hippo-cli/releases/download/${HIPPO_CLI_VERSION}/hippo-${HIPPO_CLI_VERSION}-linux-amd64.tar.gz && tar -xvf hippocli.tar.gz && mv hippo README.md LICENSE /usr/local/bin/ && cd - && rm -r hippocli 
 
 # Install bindle
-ARG BINDLE_VERSION="v0.5.0"
+ARG BINDLE_VERSION="v0.6.0"
 RUN mkdir bindle && cd bindle && curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server README.md LICENSE.txt /usr/local/bin/ && cd - && rm -r bindle
 
 # Install WAGI
-ARG WAGI_VERSION="v0.3.0"
+ARG WAGI_VERSION="v0.4.0"
 RUN mkdir wagi && cd wagi && curl -fsSLo wagi.tar.gz https://github.com/deislabs/wagi/releases/download/${WAGI_VERSION}/wagi-${WAGI_VERSION}-linux-amd64.tar.gz  && tar -xvf wagi.tar.gz && mv wagi README.md LICENSE.txt /usr/local/bin/ && cd - && rm -r wagi
 
 # Install Rust 
@@ -51,9 +51,6 @@ RUN su ${USER} -c "mkdir rust && cd rust && curl -fsSLo install_rust.sh https://
 
 # Install yo-wasm
 RUN su ${USER} -c ". /home/${USER}/.nvm/nvm.sh && npm install -g yo && npm install -g generator-wasm"
-
-# TODO remove this before release as it is temporary. The hippo enabled yo wasm package is not published yet so we need to use the one from the repo.
-RUN su ${USER} -c ". /home/${USER}/.nvm/nvm.sh && npm uninstall -g generator-wasm && mkdir yowasm && cd yowasm && curl -fsSLo ./yowasm.tar.gz https://github.com/deislabs/yo-wasm/releases/download/v0.0.4%2Bpreview2/generator-wasm-0.0.3.tgz && npm install -g ./yowasm.tar.gz && cd - && rm -r yowasm"
 
 COPY --chown=1000:1000 . /hippo
 

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -11,7 +11,7 @@ jobs:
     name: Push devcontainer/codespaces image to GitHub Package Registry
     runs-on: ubuntu-latest
     env:
-      DEVCONTAINER_VERSION: v1.0.0
+      DEVCONTAINER_VERSION: v1.0.1
     permissions:
       contents: read
       packages: write
@@ -44,8 +44,8 @@ jobs:
             VARIANT : 5.0
             NODE_VERSION: lts/*
             HIPPO_VERSION: v0.9.0
-            BINDLE_VERSION: v0.5.0
-            WAGI_VERSION: v0.3.0
+            BINDLE_VERSION: v0.6.0
+            WAGI_VERSION: v0.4.0
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/manual-build-container.yml
+++ b/.github/workflows/manual-build-container.yml
@@ -1,0 +1,73 @@
+name: Manually build and push runtime container
+on:
+  workflow_dispatch:
+
+jobs:  
+  push_to_registry:
+    name: Push image to GitHub Package Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
+      - name: Set MINVERBUILDMETADATA and Image Version Tag
+        run: |
+          echo MINVERBUILDMETADATA=$(git rev-parse --short ${GITHUB_SHA})  >> $GITHUB_ENV
+          TAG_COMMIT=$(git rev-list --tags --max-count=1)
+          echo IMAGE_VERSION_TAG=$(git describe --tags --abbrev=0 ${TAG_COMMIT})  >> $GITHUB_ENV
+        shell: bash
+
+      - name: Npm build
+        shell: bash
+        run: |
+          cd Hippo
+          npm run cibuild
+          cd ..
+
+      - name: dotnet publish
+        run: dotnet publish Hippo/Hippo.csproj -c Release --self-contained -r linux-x64
+
+      - name: Copy openssl conf
+        shell: bash
+        run: |
+          mkdir -p ./Hippo/bin/Release/net5.0/linux-x64/publish/certs
+          cp .github/release-image/localhost.conf ./Hippo/bin/Release/net5.0/linux-x64/publish/certs
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{raw}},priority=1,value=${{ env.IMAGE_VERSION_TAG }}
+            type=semver,pattern={{version}},priority=2,value=${{ env.IMAGE_VERSION_TAG }}
+            type=semver,pattern={{major}}.{{minor}},priority=3,value=${{ env.IMAGE_VERSION_TAG }}
+            type=sha,priority=4
+          flavor: |
+            latest=true
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: .github/release-image/Dockerfile
+          context: ./Hippo/bin/Release/net5.0/linux-x64/publish
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
-          dotnet-version: 5.0.x
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
Updates container definitions to use the latest versions of dependencies.

Adds a manual pipeline to enable the updating of runtime container image when dependencies have new versions but there is no new version of hippo. (As is the case with this PR where we have already released v0.1.0 but we need to update the container image associated with that version with new versions of bindle, wagi etc.)