### PR TITLE
Hippo footer docs link broken

### DIFF
--- a/Hippo/Views/Shared/_Footer.cshtml
+++ b/Hippo/Views/Shared/_Footer.cshtml
@@ -10,7 +10,7 @@
       <nav class="navbar is-transparent" role="navigation" aria-label="footer navigation">
       <div class="navbar-end">
         <ul class="inline navbar-menu">
-          <li class="navbar-item"><a href="https://github.com/deislabs/hippo/tree/main/docs">Docs</a></li>
+          <li class="navbar-item"><a href="https://docs.hippofactory.dev">Docs</a></li>
           <li class="navbar-item"><a href="https://github.com/deislabs/hippo">Github</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Docs footer link doesnt take you to the official docs

Closes #277 

Signed-off-by: Nitish Malhotra <nitish.malhotra@gmail.com>