### PR TITLE
subscribe to channel start/stop events

### DIFF
--- a/src/Hippo/Schedulers/WagiDotnetJobScheduler.cs
+++ b/src/Hippo/Schedulers/WagiDotnetJobScheduler.cs
@@ -1,6 +1,5 @@
 using Hippo.Config;
 using Hippo.Models;
-using Hippo.Proxies;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -9,8 +8,8 @@ namespace Hippo.Schedulers;
 public class WagiDotnetJobScheduler : InternalScheduler
 {
     private readonly IChannelConfigurationProvider _channelConfigurationProvider;
-    public WagiDotnetJobScheduler(ILogger<WagiDotnetJobScheduler> logger, IReverseProxy reverseProxy, IChannelConfigurationProvider channelConfigurationProvider, IHostEnvironment env)
-        : base(logger, reverseProxy, env)
+    public WagiDotnetJobScheduler(ILogger<WagiDotnetJobScheduler> logger, IChannelConfigurationProvider channelConfigurationProvider, IHostEnvironment env)
+        : base(logger, env)
     {
         _channelConfigurationProvider = channelConfigurationProvider;
         _channelConfigurationProvider.SetBindleServer(_bindleUrl);
@@ -21,12 +20,15 @@ public class WagiDotnetJobScheduler : InternalScheduler
         var port = c.PortID + Channel.EphemeralPortRange;
         var listenAddress = $"http://127.0.0.1:{port}";
         _channelConfigurationProvider.AddChannel(c, listenAddress);
-        StartProxy(c, listenAddress);
+        var data = new ChannelStartedEventArgs();
+        data.Channel = c;
+        data.ListenAddress = listenAddress;
+        OnChannelStarted(data);
     }
 
     public override void Stop(Channel c)
     {
-        StopProxy(c);
+        OnChannelStopped(c);
         _channelConfigurationProvider.RemoveChannel(c);
 
     }


### PR DESCRIPTION
If the configured job scheduler is an instance of InternalScheduler, it will subscribe to those events.

This change removes the hard dependency on reverse proxies for certain schedulers.

With this change, we should consider collapsing InternalScheduler and ExternalScheduler as one Scheduler class. Then in Startup.cs, when the reverse proxy is enabled, we subscribe it to the scheduler's event handlers. That should help solve #242.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>