### PR TITLE
update dependabot watch locations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/src/Infrastructure"
     schedule:
@@ -17,7 +17,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/src/Web"
     schedule:
@@ -26,7 +26,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/tests/Application.UnitTests"
     schedule:
@@ -35,7 +35,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/tests/Core.UnitTests"
     schedule:
@@ -44,7 +44,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "nuget"
     directory: "/tests/Hippo.FunctionalTests"
     schedule:
@@ -53,7 +53,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/src/Web"
     schedule:
@@ -62,7 +62,7 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -71,4 +71,4 @@ updates:
       time: "08:00"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,52 @@
 version: 2
 updates: 
   - package-ecosystem: "nuget"
+    directory: "/src/Application"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "nuget"
+    directory: "/src/Infrastructure"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "nuget"
     directory: "/src/Web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "nuget"
+    directory: "/tests/Application.UnitTests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "nuget"
+    directory: "/tests/Core.UnitTests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "nuget"
+    directory: "/tests/Hippo.FunctionalTests"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Core is ignored because it (intentionally) does not contain any dependencies.