### PR TITLE
drop Application.StorageId

### DIFF
--- a/src/Application/Apps/Commands/CreateAppCommand.cs
+++ b/src/Application/Apps/Commands/CreateAppCommand.cs
@@ -8,8 +8,6 @@ namespace Hippo.Application.Apps.Commands;
 public class CreateAppCommand : IRequest<Guid>
 {
     public string? Name { get; set; }
-
-    public string? StorageId { get; set; }
 }
 
 public class CreateAppCommandHandler : IRequestHandler<CreateAppCommand, Guid>
@@ -25,8 +23,7 @@ public class CreateAppCommandHandler : IRequestHandler<CreateAppCommand, Guid>
     {
         var entity = new App
         {
-            Name = request.Name,
-            StorageId = request.StorageId
+            Name = request.Name
         };
 
         entity.DomainEvents.Add(new AppCreatedEvent(entity));

--- a/src/Application/Apps/Commands/CreateAppCommandValidator.cs
+++ b/src/Application/Apps/Commands/CreateAppCommandValidator.cs
@@ -9,9 +9,7 @@ public class CreateAppCommandValidator : AbstractValidator<CreateAppCommand>
 {
     private readonly IApplicationDbContext _context;
 
-    private readonly Regex validName = new Regex("^[a-zA-Z0-9-_]*$");
-
-    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9-_/]*$");
+    private readonly Regex validName = new Regex("^[a-zA-Z0-9-_/]*$");
 
     public CreateAppCommandValidator(IApplicationDbContext context)
     {
@@ -19,15 +17,9 @@ public class CreateAppCommandValidator : AbstractValidator<CreateAppCommand>
 
         RuleFor(a => a.Name)
             .NotEmpty().WithMessage("Name is required.")
-            .MaximumLength(128)
+            .MaximumLength(200)
             .Matches(validName)
             .MustAsync(BeUniqueName).WithMessage("The specified name already exists.");
-
-        RuleFor(a => a.StorageId)
-            .NotEmpty().WithMessage("Storage ID is required.")
-            .MaximumLength(200)
-            .Matches(validStorageId);
-
     }
 
     public async Task<bool> BeUniqueName(CreateAppCommand model, string name, CancellationToken cancellationToken)

--- a/src/Application/Apps/Commands/UpdateAppCommandValidator.cs
+++ b/src/Application/Apps/Commands/UpdateAppCommandValidator.cs
@@ -9,9 +9,7 @@ public class UpdateAppCommandValidator : AbstractValidator<UpdateAppCommand>
 {
     private readonly IApplicationDbContext _context;
 
-    private readonly Regex validName = new Regex("^[a-zA-Z0-9-_]*$");
-
-    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9-_/]*$");
+    private readonly Regex validName = new Regex("^[a-zA-Z0-9-_/]*$");
 
     public UpdateAppCommandValidator(IApplicationDbContext context)
     {
@@ -19,14 +17,9 @@ public class UpdateAppCommandValidator : AbstractValidator<UpdateAppCommand>
 
         RuleFor(a => a.Name)
             .NotEmpty().WithMessage("Name is required.")
-            .MaximumLength(128)
+            .MaximumLength(200)
             .Matches(validName)
             .MustAsync(BeUniqueName).WithMessage("The specified name already exists.");
-
-        RuleFor(a => a.StorageId)
-            .NotEmpty()
-            .MaximumLength(200)
-            .Matches(validStorageId);
     }
 
     public async Task<bool> BeUniqueName(UpdateAppCommand model, string name, CancellationToken cancellationToken)

--- a/src/Application/Apps/Queries/AppDto.cs
+++ b/src/Application/Apps/Queries/AppDto.cs
@@ -17,8 +17,6 @@ public class AppDto : IMapFrom<App>
 
     public string? Name { get; set; }
 
-    public string? StorageId { get; set; }
-
     public IList<ChannelDto> Channels { get; set; }
 
     public IList<RevisionDto> Revisions { get; set; }

--- a/src/Application/Apps/Queries/AppRecord.cs
+++ b/src/Application/Apps/Queries/AppRecord.cs
@@ -15,8 +15,6 @@ public class AppRecord : IMapFrom<App>
 
     public string? Name { get; set; }
 
-    public string? StorageId { get; set; }
-
     public IList<ChannelRecord> Channels { get; set; }
 
     public IList<RevisionRecord> Revisions { get; set; }

--- a/src/Application/Revisions/Commands/RegisterRevisionCommand.cs
+++ b/src/Application/Revisions/Commands/RegisterRevisionCommand.cs
@@ -9,6 +9,8 @@ namespace Hippo.Application.Revisions.Commands;
 
 public class RegisterRevisionCommand : IRequest<RevisionsVm>
 {
+    // NOTE: We should rename this to AppName, but that will require an update to
+    // the Hippo API client libraries (and I'm lazy so...)
     public string? AppStorageId { get; set; }
 
     public string? RevisionNumber { get; set; }
@@ -30,7 +32,7 @@ public class RegisterRevisionCommandHandler : IRequestHandler<RegisterRevisionCo
     {
         RevisionsVm viewModel = new RevisionsVm();
 
-        foreach (App app in _context.Apps.Where(a => a.StorageId == request.AppStorageId))
+        foreach (App app in _context.Apps.Where(a => a.Name == request.AppStorageId))
         {
             var entity = new Revision
             {

--- a/src/Core/Entities/App.cs
+++ b/src/Core/Entities/App.cs
@@ -4,15 +4,15 @@ public class App : AuditableEntity, IHasDomainEvent
 {
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
-
-    // This is the ID in Bindle or whatever storage backend is used.  It gets composed
-    // with a revision ID to get a Bindle ID.
+    // The name of the application.
     //
-    // For example, the Weather application might have the StorageId contoso/weather.
-    // Revision 1.4.0 of the Weather application would then have the bindle id
+    // This doubles as the Bindle storage identifier. It is composed
+    // with a revision number to resolve the full Bindle id.
+    //
+    // For example, an application might have the Name contoso/weather.
+    // Revision 1.4.0 of the contoso/weather application would then have the Bindle id
     // contoso/weather/1.4.0
-    public string? StorageId { get; set; }
+    public string? Name { get; set; }
 
     public IList<Channel> Channels { get; private set; } = new List<Channel>();
 

--- a/src/Infrastructure/Data/Configurations/AppConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/AppConfiguration.cs
@@ -12,10 +12,6 @@ public class AppConfiguration : IEntityTypeConfiguration<App>
 
         builder.Property(a => a.Name)
             .IsRequired()
-            .HasMaxLength(128);
-
-        builder.Property(a => a.StorageId)
-            .IsRequired()
             .HasMaxLength(200);
     }
 }

--- a/src/Infrastructure/Data/Migrations/20220113005607_DropStorageId.Designer.cs
+++ b/src/Infrastructure/Data/Migrations/20220113005607_DropStorageId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hippo.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hippo.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220113005607_DropStorageId")]
+    partial class DropStorageId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.1");

--- a/src/Infrastructure/Data/Migrations/20220113005607_DropStorageId.cs
+++ b/src/Infrastructure/Data/Migrations/20220113005607_DropStorageId.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Infrastructure.Data.Migrations
+{
+    public partial class DropStorageId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StorageId",
+                table: "Apps");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StorageId",
+                table: "Apps",
+                type: "TEXT",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/Infrastructure/JobSchedulers/LocalJobScheduler.cs
+++ b/src/Infrastructure/JobSchedulers/LocalJobScheduler.cs
@@ -64,7 +64,7 @@ public class LocalJobScheduler : IJobScheduler, IHasDomainEvent
         var psi = new ProcessStartInfo
         {
             FileName = wagiProgram,
-            Arguments = $"-b {c.App.StorageId}/{c.ActiveRevision.RevisionNumber} --bindle-url {_bindleUrl} -l 127.0.0.1:{port} {env}",
+            Arguments = $"-b {c.App.Name}/{c.ActiveRevision.RevisionNumber} --bindle-url {_bindleUrl} -l 127.0.0.1:{port} {env}",
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             UseShellExecute = false,

--- a/src/Infrastructure/ReverseProxies/YarpReverseProxy.cs
+++ b/src/Infrastructure/ReverseProxies/YarpReverseProxy.cs
@@ -30,7 +30,7 @@ public class YarpReverseProxy : IReverseProxy
                 ClusterId = key,
                 Match = new RouteMatch
                 {
-                    Hosts = new List<string>(){c.Domain},
+                    Hosts = new List<string>() { c.Domain },
                     Path = "{**catch-all}"
                 }
             };

--- a/src/Web/Views/App/Edit.cshtml
+++ b/src/Web/Views/App/Edit.cshtml
@@ -23,17 +23,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="field is-horizontal">
-                    <div class="field-label is-normal">
-                        <label asp-for="StorageId" class="label">Bindle Name</label>
-                    </div>
-                    <div class="field-body is-normal">
-                        <div class="control">
-                            <input asp-for="StorageId" type="text" class="input" />
-                            <p asp-validation-for="StorageId" class="help is-warning"></p>
-                        </div>
-                    </div>
-                </div>
                 <div class="panel is-danger">
                     <p class="panel-heading">
                         Warning

--- a/src/Web/Views/App/New.cshtml
+++ b/src/Web/Views/App/New.cshtml
@@ -24,17 +24,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="field is-horizontal">
-                    <div class="field-label is-normal">
-                        <label asp-for="StorageId" class="control-label">Storage ID</label>
-                    </div>
-                    <div class="field-body is-normal">
-                        <div class="control">
-                            <input asp-for="StorageId" type="text" class="input" />
-                            <p asp-validation-for="StorageId" class="help is-warning"></p>
-                        </div>
-                    </div>
-                </div>
                 <div class="field is-grouped">
                     <div class="control">
                         <button type="submit" value="Create" class="button is-success is-rounded">Create Application</button>

--- a/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
+++ b/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
@@ -30,7 +30,7 @@ public class RequestLoggerTests
 
         var requestLogger = new LoggingBehaviour<CreateAppCommand>(_logger.Object, _currentUserService.Object, _identityService.Object);
 
-        await requestLogger.Process(new CreateAppCommand { Name = "helloworld", StorageId = "bacongobbler/helloworld" }, new CancellationToken());
+        await requestLogger.Process(new CreateAppCommand { Name = "bacongobbler/helloworld", }, new CancellationToken());
 
         _identityService.Verify(i => i.GetUserNameAsync(It.IsAny<string>()), Times.Once);
     }
@@ -40,7 +40,7 @@ public class RequestLoggerTests
     {
         var requestLogger = new LoggingBehaviour<CreateAppCommand>(_logger.Object, _currentUserService.Object, _identityService.Object);
 
-        await requestLogger.Process(new CreateAppCommand { Name = "helloworld", StorageId = "bacongobbler/helloworld" }, new CancellationToken());
+        await requestLogger.Process(new CreateAppCommand { Name = "bacongobbler/helloworld" }, new CancellationToken());
 
         _identityService.Verify(i => i.GetUserNameAsync(It.IsAny<string>()), Times.Never);
     }

--- a/tests/Hippo.FunctionalTests/Application/Revisions/Commands/CreateRevisionTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Revisions/Commands/CreateRevisionTests.cs
@@ -22,8 +22,7 @@ public class CreateRevisionTests : TestBase
     {
         var appId = await SendAsync(new CreateAppCommand
         {
-            Name = "foobar",
-            StorageId = "bacongobbler/foo",
+            Name = "bacongobbler/foo"
         });
 
         var command = new CreateRevisionCommand
@@ -41,8 +40,7 @@ public class CreateRevisionTests : TestBase
     {
         var appId = await SendAsync(new CreateAppCommand
         {
-            Name = "foo",
-            StorageId = "bacongobbler/foo",
+            Name = "bacongobbler/foobar"
         });
 
         var command = new CreateRevisionCommand


### PR DESCRIPTION
The application name now doubles as the Bindle storage identifier, so if I create an application with the name `bacongobbler/toast-on-demand`, that is the bindle ID that will be passed to the job scheduler.