### PR TITLE
stop all channels when storage ID has been updated

### DIFF
--- a/src/Application/Apps/Commands/UpdateAppCommand.cs
+++ b/src/Application/Apps/Commands/UpdateAppCommand.cs
@@ -18,9 +18,12 @@ public class UpdateAppCommandHandler : IRequestHandler<UpdateAppCommand>
 {
     private readonly IApplicationDbContext _context;
 
-    public UpdateAppCommandHandler(IApplicationDbContext context)
+    private readonly IJobScheduler _jobScheduler;
+
+    public UpdateAppCommandHandler(IApplicationDbContext context, IJobScheduler jobScheduler)
     {
         _context = context;
+        _jobScheduler = jobScheduler;
     }
 
     public async Task<Unit> Handle(UpdateAppCommand request, CancellationToken cancellationToken)
@@ -31,6 +34,17 @@ public class UpdateAppCommandHandler : IRequestHandler<UpdateAppCommand>
         if (entity == null)
         {
             throw new NotFoundException(nameof(App), request.Id);
+        }
+
+        // if the user changes the bindle storage id, ALL channels will stop working until the user registers new revisions that satisfy the channels' rules.
+        //
+        // TODO: how do we want to handle channels that requested ChannelRevisionSelectionStrategy.UseSpecifiedRevision?
+        if (entity.StorageId != request.StorageId)
+        {
+            foreach (var channel in entity.Channels)
+            {
+                _jobScheduler.Stop(channel);
+            }
         }
 
         entity.Name = request.Name;


### PR DESCRIPTION
If the user changes the bindle storage id, ALL channels will stop working until the user registers new revisions that satisfy the channels' rules.