### PR TITLE
extract to IConfigProvider

### DIFF
--- a/src/Infrastructure/ReverseProxies/Configuration/IConfigProvider.cs
+++ b/src/Infrastructure/ReverseProxies/Configuration/IConfigProvider.cs
@@ -1,0 +1,11 @@
+using Yarp.ReverseProxy.Configuration;
+
+namespace Hippo.Infrastructure.ReverseProxies.Configuration;
+
+public interface IConfigProvider
+{
+    void AddCluster(ClusterConfig clusterConfig);
+    void AddRoute(RouteConfig routeConfig);
+    void RemoveCluster(string id);
+    void RemoveRoute(string id);
+}

--- a/src/Infrastructure/ReverseProxies/Configuration/InMemoryConfigProvider.cs
+++ b/src/Infrastructure/ReverseProxies/Configuration/InMemoryConfigProvider.cs
@@ -7,7 +7,7 @@ namespace Hippo.Infrastructure.ReverseProxies.Configuration;
 /// <summary
 /// This IProxyConfigProvider loads routes and clusters from memory.
 /// </summary>
-public class InMemoryConfigProvider : IProxyConfigProvider
+public class InMemoryConfigProvider : IConfigProvider, IProxyConfigProvider
 {
     private List<RouteConfig> _routes = new List<RouteConfig>();
 

--- a/src/Infrastructure/ReverseProxies/YarpReverseProxy.cs
+++ b/src/Infrastructure/ReverseProxies/YarpReverseProxy.cs
@@ -11,9 +11,9 @@ public class YarpReverseProxy : IReverseProxy
     // TODO: when the host restarts, we should re-hydrate the reverse proxy route config
     //
     // We could fix this by implementing a file-backed config provider.
-    private readonly InMemoryConfigProvider _configProvider;
+    private readonly IConfigProvider _configProvider;
 
-    public YarpReverseProxy(InMemoryConfigProvider configProvider)
+    public YarpReverseProxy(IConfigProvider configProvider)
     {
         _configProvider = configProvider;
     }


### PR DESCRIPTION
abstracts away the implementation details of the InMemoryConfigProvider from YarpReverseProxy so that other config providers can be used.

Required for #368