### PR TITLE
fix CreateChannelCommand

### DIFF
--- a/src/Application/Certificates/Commands/CreateCertificateCommand.cs
+++ b/src/Application/Certificates/Commands/CreateCertificateCommand.cs
@@ -1,11 +1,7 @@
-using Hippo.Application.Common.Config;
-using Hippo.Application.Common.Exceptions;
 using Hippo.Application.Common.Interfaces;
 using Hippo.Core.Entities;
-using Hippo.Core.Enums;
 using Hippo.Core.Events;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace Hippo.Application.Certificates.Commands;
 

--- a/src/Application/Certificates/Commands/UpdateCertificateCommand.cs
+++ b/src/Application/Certificates/Commands/UpdateCertificateCommand.cs
@@ -1,8 +1,6 @@
 using Hippo.Application.Common.Exceptions;
 using Hippo.Application.Common.Interfaces;
 using Hippo.Core.Entities;
-using Hippo.Core.Enums;
-using Hippo.Core.Events;
 using MediatR;
 
 namespace Hippo.Application.Certificates.Commands;

--- a/src/Application/Channels/Commands/CreateChannelCommand.cs
+++ b/src/Application/Channels/Commands/CreateChannelCommand.cs
@@ -21,9 +21,9 @@ public class CreateChannelCommand : IRequest<Guid>
 
     public string? RangeRule { get; set; }
 
-    public Revision? ActiveRevision { get; set; }
+    public Guid? ActiveRevisionId { get; set; }
 
-    public Certificate? Certificate { get; set; }
+    public Guid? CertificateId { get; set; }
 }
 
 public class CreateChannelCommandHandler : IRequestHandler<CreateChannelCommand, Guid>
@@ -59,17 +59,12 @@ public class CreateChannelCommandHandler : IRequestHandler<CreateChannelCommand,
             Domain = (request.Domain != null) ? request.Domain : $"{request.Name}.{app.Name}.{platformDomain}",
             RevisionSelectionStrategy = request.RevisionSelectionStrategy,
             RangeRule = request.RangeRule,
-            ActiveRevision = request.ActiveRevision,
+            ActiveRevisionId = request.ActiveRevisionId,
             PortId = _context.Channels.Count(),
-            Certificate = request.Certificate
+            CertificateId = request.CertificateId
         };
 
         entity.DomainEvents.Add(new ChannelCreatedEvent(entity));
-
-        if (request.Certificate != null)
-        {
-            entity.DomainEvents.Add(new CertificateBindEvent(request.Certificate, entity));
-        }
 
         _context.Channels.Add(entity);
 

--- a/src/Application/Channels/Commands/UpdateChannelCommand.cs
+++ b/src/Application/Channels/Commands/UpdateChannelCommand.cs
@@ -2,7 +2,6 @@ using Hippo.Application.Common.Exceptions;
 using Hippo.Application.Common.Interfaces;
 using Hippo.Core.Entities;
 using Hippo.Core.Enums;
-using Hippo.Core.Events;
 using MediatR;
 
 namespace Hippo.Application.Channels.Commands;
@@ -19,9 +18,9 @@ public class UpdateChannelCommand : IRequest
 
     public string? RangeRule { get; set; }
 
-    public Revision? ActiveRevision { get; set; }
+    public Guid? ActiveRevisionId { get; set; }
 
-    public Certificate? Certificate { get; set; }
+    public Guid? CertificateId { get; set; }
 }
 
 public class UpdateChannelCommandHandler : IRequestHandler<UpdateChannelCommand>
@@ -43,26 +42,12 @@ public class UpdateChannelCommandHandler : IRequestHandler<UpdateChannelCommand>
             throw new NotFoundException(nameof(Channel), request.Id);
         }
 
-        if (request.ActiveRevision != null && request.ActiveRevision != entity.ActiveRevision)
-        {
-            entity.DomainEvents.Add(new ActiveRevisionChangedEvent(entity, request.ActiveRevision));
-        }
-
-        if (request.Certificate == null && entity.Certificate != null)
-        {
-            entity.DomainEvents.Add(new CertificateUnbindEvent(entity.Certificate, entity));
-        }
-        else if (request.Certificate != null && entity.Certificate != request.Certificate)
-        {
-            entity.DomainEvents.Add(new CertificateBindEvent(request.Certificate, entity));
-        }
-
         entity.Name = request.Name;
         entity.Domain = request.Domain;
         entity.RevisionSelectionStrategy = request.RevisionSelectionStrategy;
         entity.RangeRule = request.RangeRule;
-        entity.ActiveRevision = request.ActiveRevision;
-        entity.Certificate = request.Certificate;
+        entity.ActiveRevisionId = request.ActiveRevisionId;
+        entity.CertificateId = request.CertificateId;
 
         await _context.SaveChangesAsync(cancellationToken);
 

--- a/src/Application/Channels/EventHandlers/CertificateBindEventHandler.cs
+++ b/src/Application/Channels/EventHandlers/CertificateBindEventHandler.cs
@@ -31,7 +31,7 @@ public class CertificateBindEventHandler : INotificationHandler<DomainEventNotif
         //
         // TODO: Do we need to handle cases when the domain name changes? Perhaps we should handle that with a new event.
         //       That being said, it is likely the certificate will need to be replaced... So this may not be an issue.
-        var certificate = notification.DomainEvent.Certificate;
+        var certificate = notification.DomainEvent.Channel.Certificate!;
         var domain = notification.DomainEvent.Channel.Domain!;
         var sniOptions = new SniOptions(new SniOptions.CertificateOptions(certificate.PublicKey!, certificate.PrivateKey!, Path.Combine(System.IO.Directory.GetCurrentDirectory(), domain)));
 

--- a/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
+++ b/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
@@ -37,12 +37,7 @@ public class RevisionCreatedEventHandler : INotificationHandler<DomainEventNotif
         {
             if (channel.RevisionSelectionStrategy == ChannelRevisionSelectionStrategy.UseRangeRule)
             {
-                var newActiveRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
-                if (newActiveRevision != null && newActiveRevision != channel.ActiveRevision)
-                {
-                    channel.DomainEvents.Add(new ActiveRevisionChangedEvent(channel, newActiveRevision));
-                }
-                channel.ActiveRevision = newActiveRevision;
+                channel.ActiveRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
             }
         }
 

--- a/src/Application/Revisions/EventHandlers/RevisionDeletedEventHandler.cs
+++ b/src/Application/Revisions/EventHandlers/RevisionDeletedEventHandler.cs
@@ -37,12 +37,7 @@ public class RevisionDeletedEventHandler : INotificationHandler<DomainEventNotif
         {
             if (channel.RevisionSelectionStrategy == ChannelRevisionSelectionStrategy.UseSpecifiedRevision)
             {
-                var newActiveRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
-                if (newActiveRevision != null && newActiveRevision != channel.ActiveRevision)
-                {
-                    channel.DomainEvents.Add(new ActiveRevisionChangedEvent(channel, newActiveRevision));
-                }
-                channel.ActiveRevision = newActiveRevision;
+                channel.ActiveRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
             }
         }
 

--- a/src/Core/Entities/Channel.cs
+++ b/src/Core/Entities/Channel.cs
@@ -35,13 +35,14 @@ public class Channel : AuditableEntity, IHasDomainEvent
         get => _certificateId;
         set
         {
-            if (value != null && _certificateId == null)
-            {
-                DomainEvents.Add(new CertificateBindEvent(this));
-            }
-            else if (value == null && _certificateId != null)
+            if (_certificateId != null && value != _certificateId)
             {
                 DomainEvents.Add(new CertificateUnbindEvent(this));
+            }
+
+            if (value != null)
+            {
+                DomainEvents.Add(new CertificateBindEvent(this));
             }
 
             _certificateId = value;

--- a/src/Core/Entities/Channel.cs
+++ b/src/Core/Entities/Channel.cs
@@ -12,7 +12,41 @@ public class Channel : AuditableEntity, IHasDomainEvent
 
     public string? RangeRule { get; set; }
 
+    private Guid? _activeRevisionId;
+    public Guid? ActiveRevisionId
+    {
+        get => _activeRevisionId;
+        set
+        {
+            if (value != _activeRevisionId)
+            {
+                DomainEvents.Add(new ActiveRevisionChangedEvent(this));
+            }
+
+            _activeRevisionId = value;
+        }
+    }
+
     public Revision? ActiveRevision { get; set; }
+
+    private Guid? _certificateId;
+    public Guid? CertificateId
+    {
+        get => _certificateId;
+        set
+        {
+            if (value != null && _certificateId == null)
+            {
+                DomainEvents.Add(new CertificateBindEvent(this));
+            }
+            else if (value == null && _certificateId != null)
+            {
+                DomainEvents.Add(new CertificateUnbindEvent(this));
+            }
+
+            _certificateId = value;
+        }
+    }
 
     public Certificate? Certificate { get; set; }
 

--- a/src/Core/Events/ActiveRevisionChangedEvent.cs
+++ b/src/Core/Events/ActiveRevisionChangedEvent.cs
@@ -2,16 +2,10 @@ namespace Hippo.Core.Events;
 
 public class ActiveRevisionChangedEvent : DomainEvent
 {
-    public ActiveRevisionChangedEvent(Channel channel, Revision changedTo)
+    public ActiveRevisionChangedEvent(Channel channel)
     {
         Channel = channel;
-        ChangedFrom = channel.ActiveRevision;
-        ChangedTo = changedTo;
     }
 
     public Channel Channel { get; }
-
-    public Revision? ChangedFrom { get; }
-
-    public Revision ChangedTo { get; }
 }

--- a/src/Core/Events/CertificateBindEvent.cs
+++ b/src/Core/Events/CertificateBindEvent.cs
@@ -2,13 +2,10 @@ namespace Hippo.Core.Events;
 
 public class CertificateBindEvent : DomainEvent
 {
-    public CertificateBindEvent(Certificate certificate, Channel channel)
+    public CertificateBindEvent(Channel channel)
     {
-        Certificate = certificate;
         Channel = channel;
     }
-
-    public Certificate Certificate { get; }
 
     public Channel Channel { get; }
 }

--- a/src/Core/Events/CertificateUnbindEvent.cs
+++ b/src/Core/Events/CertificateUnbindEvent.cs
@@ -2,13 +2,10 @@ namespace Hippo.Core.Events;
 
 public class CertificateUnbindEvent : DomainEvent
 {
-    public CertificateUnbindEvent(Certificate certificate, Channel channel)
+    public CertificateUnbindEvent(Channel channel)
     {
-        Certificate = certificate;
         Channel = channel;
     }
-
-    public Certificate Certificate { get; }
 
     public Channel Channel { get; }
 }

--- a/src/Core/_Imports.cs
+++ b/src/Core/_Imports.cs
@@ -1,3 +1,4 @@
 global using Hippo.Core.Common;
 global using Hippo.Core.Entities;
 global using Hippo.Core.Enums;
+global using Hippo.Core.Events;

--- a/src/Web/Controllers/ChannelController.cs
+++ b/src/Web/Controllers/ChannelController.cs
@@ -51,7 +51,7 @@ public class ChannelController : WebUIControllerBase
         try
         {
             ChannelDto dto = await Mediator.Send(new GetChannelQuery { Id = id });
-            
+
             return View(new UpdateChannelCommand
             {
                 Id = dto.Id,
@@ -59,7 +59,7 @@ public class ChannelController : WebUIControllerBase
                 Domain = dto.Domain,
                 RevisionSelectionStrategy = dto.RevisionSelectionStrategy,
                 RangeRule = dto.RangeRule,
-                ActiveRevision = dto.ActiveRevision
+                ActiveRevisionId = dto.ActiveRevision?.Id
             });
         }
         catch (NotFoundException)

--- a/tests/Core.UnitTests/Events/EventTests.cs
+++ b/tests/Core.UnitTests/Events/EventTests.cs
@@ -66,13 +66,11 @@ public class EventTests
     [Fact]
     public void ActiveRevisionChangedEventTest()
     {
+        var oldRevision = new Revision { RevisionNumber = "1.0.0" };
+        var newRevision = new Revision { RevisionNumber = "2.0.0" };
         var channel = new Channel();
-        var oldVersion = "1.0.0";
-        var newVersion = "2.0.0";
-        channel.ActiveRevision = new Revision { RevisionNumber = oldVersion };
-        var @event = new ActiveRevisionChangedEvent(channel, new Revision { RevisionNumber = newVersion });
-        Assert.Equal(channel, @event.Channel);
-        Assert.Equal(oldVersion, @event.ChangedFrom!.RevisionNumber);
-        Assert.Equal(newVersion, @event.ChangedTo.RevisionNumber);
+        channel.ActiveRevisionId = oldRevision.Id;
+        channel.ActiveRevisionId = newRevision.Id;
+        Assert.Single(channel.DomainEvents);
     }
 }

--- a/tests/Hippo.FunctionalTests/Application/Channels/Commands/CreateChannelTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Channels/Commands/CreateChannelTests.cs
@@ -103,8 +103,7 @@ public class CreateChannelTests : TestBase
             Name = name,
             AppId = appId,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevisionId = null
+            RangeRule = "*"
         };
 
         await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(command));

--- a/tests/Hippo.FunctionalTests/Application/Channels/Commands/CreateChannelTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Channels/Commands/CreateChannelTests.cs
@@ -41,8 +41,7 @@ public class CreateChannelTests : TestBase
             Name = "development",
             AppId = appId1,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevision = null
+            RangeRule = "*"
         });
 
         var command = new CreateChannelCommand
@@ -50,8 +49,7 @@ public class CreateChannelTests : TestBase
             Name = "development",
             AppId = appId1,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevision = null
+            RangeRule = "*"
         };
 
         await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(command));
@@ -81,7 +79,7 @@ public class CreateChannelTests : TestBase
             AppId = appId,
             RevisionSelectionStrategy = revisionSelectionStrategy,
             RangeRule = rangeRule,
-            ActiveRevision = activeRevision
+            ActiveRevisionId = activeRevision?.Id
         };
 
         await SendAsync(command);
@@ -106,7 +104,7 @@ public class CreateChannelTests : TestBase
             AppId = appId,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
             RangeRule = "*",
-            ActiveRevision = null
+            ActiveRevisionId = null
         };
 
         await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(command));

--- a/tests/Hippo.FunctionalTests/Application/Channels/Commands/UpdateChannelTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Channels/Commands/UpdateChannelTests.cs
@@ -25,8 +25,7 @@ public class UpdateChannelTests : TestBase
             Name = "ShouldValidateDomain",
             AppId = appId,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevision = null
+            RangeRule = "*"
         };
 
         var channelId = await SendAsync(createChannelCommand);
@@ -54,8 +53,7 @@ public class UpdateChannelTests : TestBase
             Name = "ShouldValidateUniqueName",
             AppId = appId,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevision = null
+            RangeRule = "*"
         };
 
         var channelId = await SendAsync(createChannelCommand);
@@ -65,8 +63,7 @@ public class UpdateChannelTests : TestBase
             Name = "ShouldValidateUniqueName2",
             AppId = appId,
             RevisionSelectionStrategy = ChannelRevisionSelectionStrategy.UseRangeRule,
-            RangeRule = "*",
-            ActiveRevision = null
+            RangeRule = "*"
         });
 
         var command = new UpdateChannelCommand


### PR DESCRIPTION
The API should be accepting a Certificate ID rather than a concrete object type.

I also refactored some of the DomainEvents such that the code remains a little more DRY.

This was discovered while integrating hippo-openapi into hippo-cli via https://github.com/deislabs/hippo-cli/pull/99. This is a breaking change to the API and will require the clients to be regenerated.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>