### PR TITLE
fix(ui): delete confirmations using correct method

### DIFF
--- a/src/Web/Controllers/AppController.cs
+++ b/src/Web/Controllers/AppController.cs
@@ -103,7 +103,7 @@ public class AppController : WebUIControllerBase
         }
     }
 
-    [HttpDelete]
+    [HttpPost]
     public async Task<IActionResult> Delete(DeleteAppCommand command)
     {
         try

--- a/src/Web/Controllers/ChannelController.cs
+++ b/src/Web/Controllers/ChannelController.cs
@@ -98,7 +98,7 @@ public class ChannelController : WebUIControllerBase
         }
     }
 
-    [HttpDelete]
+    [HttpPost]
     public async Task<IActionResult> Delete(DeleteChannelCommand command)
     {
         try

--- a/src/Web/Controllers/EnvironmentVariableController.cs
+++ b/src/Web/Controllers/EnvironmentVariableController.cs
@@ -96,7 +96,7 @@ public class EnvironmentVariableController : WebUIControllerBase
         }
     }
 
-    [HttpDelete]
+    [HttpPost]
     public async Task<IActionResult> Delete(DeleteEnvironmentVariableCommand command)
     {
         try


### PR DESCRIPTION
HTML forms do not allow for DELETE methods.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>