### PR TITLE
better openapi generation

### DIFF
--- a/src/Application/Accounts/Commands/CreateAccountCommand.cs
+++ b/src/Application/Accounts/Commands/CreateAccountCommand.cs
@@ -5,11 +5,11 @@ namespace Hippo.Application.Accounts.Commands;
 
 public class CreateAccountCommand : IRequest<string>
 {
-    public string? UserName { get; set; }
+    public string UserName { get; set; } = "";
 
-    public string? Password { get; set; }
+    public string Password { get; set; } = "";
 
-    public string? PasswordConfirm { get; set; }
+    public string PasswordConfirm { get; set; } = "";
 }
 
 public class CreateAccountCommandHandler : IRequestHandler<CreateAccountCommand, string>
@@ -23,7 +23,7 @@ public class CreateAccountCommandHandler : IRequestHandler<CreateAccountCommand,
 
     public async Task<string> Handle(CreateAccountCommand request, CancellationToken cancellationToken)
     {
-        var result = await _identityService.CreateUserAsync(request.UserName!, request.Password!);
+        var result = await _identityService.CreateUserAsync(request.UserName, request.Password);
 
         return result.UserId;
     }

--- a/src/Application/Accounts/Commands/CreateTokenCommand.cs
+++ b/src/Application/Accounts/Commands/CreateTokenCommand.cs
@@ -6,15 +6,9 @@ namespace Hippo.Application.Accounts.Commands;
 
 public class CreateTokenCommand : IRequest<TokenInfo>
 {
-    public string UserName { get; set; }
+    public string UserName { get; set; } = "";
 
-    public string Password { get; set; }
-
-    public CreateTokenCommand(string username, string password)
-    {
-        UserName = username;
-        Password = password;
-    }
+    public string Password { get; set; } = "";
 }
 
 public class CreateTokenCommandHandler : IRequestHandler<CreateTokenCommand, TokenInfo>

--- a/src/Application/Accounts/Commands/LoginAccountCommand.cs
+++ b/src/Application/Accounts/Commands/LoginAccountCommand.cs
@@ -6,9 +6,9 @@ namespace Hippo.Application.Accounts.Commands;
 
 public class LoginAccountCommand : IRequest
 {
-    public string? UserName { get; set; }
+    public string UserName { get; set; } = "";
 
-    public string? Password { get; set; }
+    public string Password { get; set; } = "";
 
     public bool RememberMe { get; set; }
 }

--- a/src/Application/Accounts/Commands/LogoutAccountCommand.cs
+++ b/src/Application/Accounts/Commands/LogoutAccountCommand.cs
@@ -3,9 +3,7 @@ using MediatR;
 
 namespace Hippo.Application.Accounts.Commands;
 
-public class LogoutAccountCommand : IRequest
-{
-}
+public class LogoutAccountCommand : IRequest { }
 
 public class LogoutAccountCommandHandler : IRequestHandler<LogoutAccountCommand>
 {

--- a/src/Application/Apps/Commands/CreateAppCommand.cs
+++ b/src/Application/Apps/Commands/CreateAppCommand.cs
@@ -7,9 +7,9 @@ namespace Hippo.Application.Apps.Commands;
 
 public class CreateAppCommand : IRequest<Guid>
 {
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? StorageId { get; set; }
+    public string StorageId { get; set; } = "";
 }
 
 public class CreateAppCommandHandler : IRequestHandler<CreateAppCommand, Guid>

--- a/src/Application/Apps/Commands/PurgeAppsCommand.cs
+++ b/src/Application/Apps/Commands/PurgeAppsCommand.cs
@@ -8,9 +8,7 @@ namespace Hippo.Application.Apps.Commands;
 
 [Authorize(Roles = "Administrator")]
 [Authorize(Policy = "CanPurge")]
-public class PurgeAppsCommand : IRequest
-{
-}
+public class PurgeAppsCommand : IRequest { }
 
 public class PurgeAppsCommandHandler : IRequestHandler<PurgeAppsCommand>
 {

--- a/src/Application/Apps/Commands/UpdateAppCommand.cs
+++ b/src/Application/Apps/Commands/UpdateAppCommand.cs
@@ -9,9 +9,9 @@ public class UpdateAppCommand : IRequest
 {
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? StorageId { get; set; }
+    public string StorageId { get; set; } = "";
 }
 
 public class UpdateAppCommandHandler : IRequestHandler<UpdateAppCommand>

--- a/src/Application/Apps/Queries/AppDto.cs
+++ b/src/Application/Apps/Queries/AppDto.cs
@@ -15,9 +15,9 @@ public class AppDto : IMapFrom<App>
 
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? StorageId { get; set; }
+    public string StorageId { get; set; } = "";
 
     public IList<ChannelDto> Channels { get; set; }
 

--- a/src/Application/Apps/Queries/AppRecord.cs
+++ b/src/Application/Apps/Queries/AppRecord.cs
@@ -13,9 +13,9 @@ public class AppRecord : IMapFrom<App>
         Revisions = new List<RevisionRecord>();
     }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? StorageId { get; set; }
+    public string StorageId { get; set; } = "";
 
     public IList<ChannelRecord> Channels { get; set; }
 

--- a/src/Application/Apps/Queries/AppsVm.cs
+++ b/src/Application/Apps/Queries/AppsVm.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Hippo.Application.Apps.Queries;
 
 public class AppsVm
 {
+    [Required]
     public IList<AppDto> Apps { get; set; } = new List<AppDto>();
 }

--- a/src/Application/Certificates/Commands/CreateCertificateCommand.cs
+++ b/src/Application/Certificates/Commands/CreateCertificateCommand.cs
@@ -7,11 +7,11 @@ namespace Hippo.Application.Certificates.Commands;
 
 public class CreateCertificateCommand : IRequest<Guid>
 {
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? PublicKey { get; set; }
+    public string PublicKey { get; set; } = "";
 
-    public string? PrivateKey { get; set; }
+    public string PrivateKey { get; set; } = "";
 }
 
 public class CreateCertificateCommandHandler : IRequestHandler<CreateCertificateCommand, Guid>

--- a/src/Application/Certificates/Commands/PurgeCertificatesCommand.cs
+++ b/src/Application/Certificates/Commands/PurgeCertificatesCommand.cs
@@ -8,9 +8,7 @@ namespace Hippo.Application.Certificates.Commands;
 
 [Authorize(Roles = "Administrator")]
 [Authorize(Policy = "CanPurge")]
-public class PurgeCertificatesCommand : IRequest
-{
-}
+public class PurgeCertificatesCommand : IRequest { }
 
 public class PurgeCertificatesCommandHandler : IRequestHandler<PurgeCertificatesCommand>
 {

--- a/src/Application/Certificates/Commands/UpdateCertificateCommand.cs
+++ b/src/Application/Certificates/Commands/UpdateCertificateCommand.cs
@@ -9,11 +9,11 @@ public class UpdateCertificateCommand : IRequest
 {
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? PublicKey { get; set; }
+    public string PublicKey { get; set; } = "";
 
-    public string? PrivateKey { get; set; }
+    public string PrivateKey { get; set; } = "";
 }
 
 public class UpdateCertificateCommandHandler : IRequestHandler<UpdateCertificateCommand>

--- a/src/Application/Certificates/Queries/CertificateDto.cs
+++ b/src/Application/Certificates/Queries/CertificateDto.cs
@@ -15,11 +15,11 @@ public class CertificateDto : IMapFrom<Certificate>
 
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? PublicKey { get; set; }
+    public string PublicKey { get; set; } = "";
 
-    public string? PrivateKey { get; set; }
+    public string PrivateKey { get; set; } = "";
 
     public IList<ChannelDto> Channels { get; set; }
 }

--- a/src/Application/Certificates/Queries/CertificateRecord.cs
+++ b/src/Application/Certificates/Queries/CertificateRecord.cs
@@ -13,11 +13,11 @@ public class CertificateRecord : IMapFrom<Certificate>
         Channels = new List<ChannelDto>();
     }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? PublicKey { get; set; }
+    public string PublicKey { get; set; } = "";
 
-    public string? PrivateKey { get; set; }
+    public string PrivateKey { get; set; } = "";
 
     public IList<ChannelDto> Channels { get; set; }
 }

--- a/src/Application/Certificates/Queries/CertificatesVm.cs
+++ b/src/Application/Certificates/Queries/CertificatesVm.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Hippo.Application.Certificates.Queries;
 
 public class CertificatesVm
 {
+    [Required]
     public IList<CertificateDto> Certificates { get; set; } = new List<CertificateDto>();
 }

--- a/src/Application/Channels/Commands/CreateChannelCommand.cs
+++ b/src/Application/Channels/Commands/CreateChannelCommand.cs
@@ -13,7 +13,7 @@ public class CreateChannelCommand : IRequest<Guid>
 {
     public Guid AppId { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
     public string? Domain { get; set; }
 

--- a/src/Application/Channels/Commands/PurgeChannelsCommand.cs
+++ b/src/Application/Channels/Commands/PurgeChannelsCommand.cs
@@ -8,9 +8,7 @@ namespace Hippo.Application.Channels.Commands;
 
 [Authorize(Roles = "Administrator")]
 [Authorize(Policy = "CanPurge")]
-public class PurgeChannelsCommand : IRequest
-{
-}
+public class PurgeChannelsCommand : IRequest { }
 
 public class PurgeChannelsCommandHandler : IRequestHandler<PurgeChannelsCommand>
 {

--- a/src/Application/Channels/Commands/UpdateChannelCommand.cs
+++ b/src/Application/Channels/Commands/UpdateChannelCommand.cs
@@ -10,9 +10,9 @@ public class UpdateChannelCommand : IRequest
 {
     public Guid Id { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? Domain { get; set; }
+    public string Domain { get; set; } = "";
 
     public ChannelRevisionSelectionStrategy RevisionSelectionStrategy { get; set; }
 

--- a/src/Application/Channels/Queries/ChannelDto.cs
+++ b/src/Application/Channels/Queries/ChannelDto.cs
@@ -16,9 +16,9 @@ public class ChannelDto : IMapFrom<Channel>
 
     public Guid AppId { get; set; }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? Domain { get; set; }
+    public string Domain { get; set; } = "";
 
     public ChannelRevisionSelectionStrategy RevisionSelectionStrategy { get; set; }
 

--- a/src/Application/Channels/Queries/ChannelRecord.cs
+++ b/src/Application/Channels/Queries/ChannelRecord.cs
@@ -13,9 +13,9 @@ public class ChannelRecord : IMapFrom<Channel>
         EnvironmentVariables = new List<EnvironmentVariableRecord>();
     }
 
-    public string? Name { get; set; }
+    public string Name { get; set; } = "";
 
-    public string? Domain { get; set; }
+    public string Domain { get; set; } = "";
 
     public ChannelRevisionSelectionStrategy RevisionSelectionStrategy { get; set; }
 

--- a/src/Application/Channels/Queries/ChannelsVm.cs
+++ b/src/Application/Channels/Queries/ChannelsVm.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Hippo.Application.Channels.Queries;
 
 public class ChannelsVm
 {
+    [Required]
     public IList<ChannelDto> Channels { get; set; } = new List<ChannelDto>();
 }

--- a/src/Application/EnvironmentVariables/Commands/CreateEnvironmentVariableCommand.cs
+++ b/src/Application/EnvironmentVariables/Commands/CreateEnvironmentVariableCommand.cs
@@ -7,9 +7,9 @@ namespace Hippo.Application.EnvironmentVariables.Commands;
 
 public class CreateEnvironmentVariableCommand : IRequest<Guid>
 {
-    public string? Key { get; set; }
+    public string Key { get; set; } = "";
 
-    public string? Value { get; set; }
+    public string Value { get; set; } = "";
 
     public Guid ChannelId { get; set; }
 }

--- a/src/Application/EnvironmentVariables/Commands/PurgeEnvironmentVariablesCommand.cs
+++ b/src/Application/EnvironmentVariables/Commands/PurgeEnvironmentVariablesCommand.cs
@@ -8,9 +8,7 @@ namespace Hippo.Application.EnvironmentVariables.Commands;
 
 [Authorize(Roles = "Administrator")]
 [Authorize(Policy = "CanPurge")]
-public class PurgeEnvironmentVariablesCommand : IRequest
-{
-}
+public class PurgeEnvironmentVariablesCommand : IRequest { }
 
 public class PurgeEnvironmentVariablesCommandHandler : IRequestHandler<PurgeEnvironmentVariablesCommand>
 {

--- a/src/Application/EnvironmentVariables/Commands/UpdateEnvironmentVariableCommand.cs
+++ b/src/Application/EnvironmentVariables/Commands/UpdateEnvironmentVariableCommand.cs
@@ -10,9 +10,9 @@ public class UpdateEnvironmentVariableCommand : IRequest
 {
     public Guid Id { get; set; }
 
-    public string? Key { get; set; }
+    public string Key { get; set; } = "";
 
-    public string? Value { get; set; }
+    public string Value { get; set; } = "";
 }
 
 public class UpdateEnvironmentVariableCommandHandler : IRequestHandler<UpdateEnvironmentVariableCommand>

--- a/src/Application/EnvironmentVariables/Queries/EnvironmentVariableDto.cs
+++ b/src/Application/EnvironmentVariables/Queries/EnvironmentVariableDto.cs
@@ -9,7 +9,7 @@ public class EnvironmentVariableDto : IMapFrom<EnvironmentVariable>
 
     public Guid ChannelId { get; set; }
 
-    public string? Key { get; set; }
+    public string Key { get; set; } = "";
 
-    public string? Value { get; set; }
+    public string Value { get; set; } = "";
 }

--- a/src/Application/EnvironmentVariables/Queries/EnvironmentVariableRecord.cs
+++ b/src/Application/EnvironmentVariables/Queries/EnvironmentVariableRecord.cs
@@ -5,7 +5,7 @@ namespace Hippo.Application.EnvironmentVariables.Queries;
 
 public class EnvironmentVariableRecord : IMapFrom<EnvironmentVariable>
 {
-    public string? Key { get; set; }
+    public string Key { get; set; } = "";
 
-    public string? Value { get; set; }
+    public string Value { get; set; } = "";
 }

--- a/src/Application/EnvironmentVariables/Queries/EnvironmentVariablesVm.cs
+++ b/src/Application/EnvironmentVariables/Queries/EnvironmentVariablesVm.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Hippo.Application.EnvironmentVariables.Queries;
 
 public class EnvironmentVariablesVm
 {
+    [Required]
     public IList<EnvironmentVariableDto> EnvironmentVariables { get; set; } = new List<EnvironmentVariableDto>();
 }

--- a/src/Application/Revisions/Commands/CreateRevisionCommand.cs
+++ b/src/Application/Revisions/Commands/CreateRevisionCommand.cs
@@ -9,7 +9,7 @@ public class CreateRevisionCommand : IRequest<Guid>
 {
     public Guid AppId { get; set; }
 
-    public string? RevisionNumber { get; set; }
+    public string RevisionNumber { get; set; } = "";
 }
 
 public class CreateRevisionCommandHandler : IRequestHandler<CreateRevisionCommand, Guid>

--- a/src/Application/Revisions/Commands/PurgeRevisionsCommand.cs
+++ b/src/Application/Revisions/Commands/PurgeRevisionsCommand.cs
@@ -8,9 +8,7 @@ namespace Hippo.Application.Revisions.Commands;
 
 [Authorize(Roles = "Administrator")]
 [Authorize(Policy = "CanPurge")]
-public class PurgeRevisionsCommand : IRequest
-{
-}
+public class PurgeRevisionsCommand : IRequest { }
 
 public class PurgeRevisionsCommandHandler : IRequestHandler<PurgeRevisionsCommand>
 {

--- a/src/Application/Revisions/Commands/RegisterRevisionCommand.cs
+++ b/src/Application/Revisions/Commands/RegisterRevisionCommand.cs
@@ -9,9 +9,9 @@ namespace Hippo.Application.Revisions.Commands;
 
 public class RegisterRevisionCommand : IRequest<RevisionsVm>
 {
-    public string? AppStorageId { get; set; }
+    public string AppStorageId { get; set; } = "";
 
-    public string? RevisionNumber { get; set; }
+    public string RevisionNumber { get; set; } = "";
 }
 
 public class RegisterRevisionCommandHandler : IRequestHandler<RegisterRevisionCommand, RevisionsVm>

--- a/src/Application/Revisions/Commands/RegisterRevisionCommandValidator.cs
+++ b/src/Application/Revisions/Commands/RegisterRevisionCommandValidator.cs
@@ -1,11 +1,19 @@
+using System.Text.RegularExpressions;
 using FluentValidation;
 
 namespace Hippo.Application.Revisions.Commands;
 
 public class RegisterRevisionCommandValidator : AbstractValidator<RegisterRevisionCommand>
 {
+    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9-_/]*$");
+
     public RegisterRevisionCommandValidator()
     {
+        RuleFor(v => v.AppStorageId)
+            .NotEmpty().WithMessage("Storage ID is required.")
+            .MaximumLength(200)
+            .Matches(validStorageId);
+
         RuleFor(v => v.RevisionNumber)
             .NotEmpty()
             .MaximumLength(128);

--- a/src/Application/Revisions/Queries/RevisionDto.cs
+++ b/src/Application/Revisions/Queries/RevisionDto.cs
@@ -9,7 +9,7 @@ public class RevisionDto : IMapFrom<Revision>
 
     public Guid AppId { get; set; }
 
-    public string? RevisionNumber { get; set; }
+    public string RevisionNumber { get; set; } = "";
 
     public string OrderKey()
     {

--- a/src/Application/Revisions/Queries/RevisionRecord.cs
+++ b/src/Application/Revisions/Queries/RevisionRecord.cs
@@ -5,5 +5,5 @@ namespace Hippo.Application.Revisions.Queries;
 
 public class RevisionRecord : IMapFrom<Revision>
 {
-    public string? RevisionNumber { get; set; }
+    public string RevisionNumber { get; set; } = "";
 }

--- a/src/Application/Revisions/Queries/RevisionsVm.cs
+++ b/src/Application/Revisions/Queries/RevisionsVm.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Hippo.Application.Revisions.Queries;
 
 public class RevisionsVm
 {
+    [Required]
     public IList<RevisionDto> Revisions { get; set; } = new List<RevisionDto>();
 }

--- a/src/Web/Views/Channel/New.cshtml
+++ b/src/Web/Views/Channel/New.cshtml
@@ -82,7 +82,7 @@
                     <div class="field-body is-normal">
                         <div class="field">
                             <input asp-for="RangeRule" asp-items="Model.Revisions" class="input is-normal is-medium is-primary" placeholder="*" />
-                            <p><small class="is-info">You can choose to deply all versions of your app (enter an <code>*</code>) or limit deploys to a specific range.</small></p>
+                            <p><small class="is-info">You can choose to deploy all versions of your app (enter an <code>*</code>) or limit deploys to a specific range.</small></p>
 
                             <p><small class="is-info">Examples:<br>
                             To deploy minor releases that follow v1.0, set the range to <code>1<</code>. To follow v1.0 but exclude releases beyond v2.0, set the range to <code>1-2</code>.</small></p>

--- a/tests/Hippo.FunctionalTests/Application/Accounts/Commands/CreateAccountTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Accounts/Commands/CreateAccountTests.cs
@@ -8,63 +8,46 @@ namespace Hippo.FunctionalTests.Application.Accounts.Commands;
 public class CreateAccountTests : TestBase
 {
     [Fact]
-    public async Task ShouldRequireMinimumFields()
-    {
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand()));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { UserName = "bacongobbler" }));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { Password = "bacongobbler" }));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { PasswordConfirm = "bacongobbler" }));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { UserName = "bacongobbler", Password = "Passw0rd!" }));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { UserName = "bacongobbler", PasswordConfirm = "Passw0rd!" }));
-        await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(new CreateAccountCommand { Password = "Passw0rd!", PasswordConfirm = "Passw0rd!" }));
-    }
-
-    [Fact]
     public async Task ShouldRequireUniqueUserName()
     {
-        await SendAsync(new CreateAccountCommand
-        {
-            UserName = "bob",
-            Password = "Passw0rd!",
-            PasswordConfirm = "Passw0rd!"
-        });
-
-        var command = new CreateAccountCommand
-        {
+        var command = new CreateAccountCommand{
             UserName = "bob",
             Password = "Passw0rd!",
             PasswordConfirm = "Passw0rd!"
         };
 
+        await SendAsync(command);
+
         await Assert.ThrowsAsync<ValidationException>(async () => await SendAsync(command));
     }
 
     [Theory]
-    [InlineData("bacongobbler", "Passw0rd!", "Passw0rd!")]
-    public void ShouldCreateAccount(string userName, string password, string passwordConfirm)
+    [InlineData("bacongobbler", "Passw0rd!")]
+    public void ShouldCreateAccount(string userName, string password)
     {
-        var command = new CreateAccountCommand
-        {
+        var command = new CreateAccountCommand{
             UserName = userName,
             Password = password,
-            PasswordConfirm = passwordConfirm
+            PasswordConfirm = password
         };
 
         Assert.True(SendAsync(command).IsCompletedSuccessfully);
     }
 
     [Theory]
+    [InlineData("", "Passw0rd!", "Passw0rd!")]
+    [InlineData("bacongobbler", "", "Passw0rd!")]
+    [InlineData("bacongobbler", "Passw0rd!", "")]
+    [InlineData("", "", "Passw0rd!")]
+    [InlineData("bacongobbler", "", "")]
+    [InlineData("", "Passw0rd!", "")]
+    [InlineData("", "", "")]
     [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "Passw0rd!", "Passw0rd!")]
     [InlineData("!@#$%^&*(){}[]<>\\|'\";:,./?=+", "Passw0rd!", "Passw0rd!")]
     [InlineData("Bobby Tables", "Passw0rd!", "Passw0rd!")]
-    [InlineData("", "Passw0rd!", "Passw0rd!")]
-    [InlineData("bacongobbler", "", "")]
-    [InlineData("bacongobbler", "", "Passw0rd!")]
-    [InlineData("bacongobbler", "Passw0rd!", "")]
     public async Task ShouldNotCreateAccount(string userName, string password, string passwordConfirm)
     {
-        var command = new CreateAccountCommand
-        {
+        var command = new CreateAccountCommand{
             UserName = userName,
             Password = password,
             PasswordConfirm = passwordConfirm


### PR DESCRIPTION
The previous swagger.json file accepted null values where the command
validators would prevent that from happening. This change makes those
fields required.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>