### PR TITLE
Add --self-contained to satisfy warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
 
       - name: dotnet publish
-        run: dotnet publish src/Web/Web.csproj --runtime "${{ matrix.target }}" -c Release -o ${{ matrix.target }}
+        run: dotnet publish src/Web/Web.csproj --runtime "${{ matrix.target }}" -c Release --self-contained -o ${{ matrix.target }}
 
       - name: Package
         shell: bash


### PR DESCRIPTION
This is the default option, though without --self-contained present it
will emit a warning.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>