### PR TITLE
rename "Stopped" as "Canceled"

### DIFF
--- a/src/Application/Jobs/Job.cs
+++ b/src/Application/Jobs/Job.cs
@@ -55,7 +55,7 @@ public abstract class Job
                 case JobStatus.Created:
                 case JobStatus.WaitingToRun:
                     return cancellationToken.IsCancellationRequested;
-                case JobStatus.Stopped:
+                case JobStatus.Canceled:
                     return true;
                 default:
                     return false;
@@ -70,7 +70,7 @@ public abstract class Job
             switch (_status)
             {
                 case JobStatus.Completed:
-                case JobStatus.Stopped:
+                case JobStatus.Canceled:
                 case JobStatus.Unknown:
                     return true;
                 default:
@@ -131,5 +131,10 @@ public abstract class Job
         }
     }
 
+    /// <summary>
+    /// Stops the <see cref="Job" />, marking it as completed.
+    /// </summary>
     public abstract void Stop();
+
+
 }

--- a/src/Application/Jobs/JobStatus.cs
+++ b/src/Application/Jobs/JobStatus.cs
@@ -10,8 +10,8 @@ public enum JobStatus
     Running,
     /// The job completed execution successfully.
     Completed,
-    /// The job acknowledged that it has been stopped.
-    Stopped,
+    /// The job acknowledged that it has been canceled.
+    Canceled,
     /// The job's status is unknown due to an unhandled exception.
     Unknown,
 }

--- a/src/Infrastructure/Jobs/LocalJob.cs
+++ b/src/Infrastructure/Jobs/LocalJob.cs
@@ -47,7 +47,7 @@ public class LocalJob : Job
             cancellationToken.Register(() =>
             {
                 process.Kill();
-                _status = JobStatus.Stopped;
+                _status = JobStatus.Canceled;
             });
         }
         catch (Win32Exception e)  // yes, even on Linux

--- a/src/Infrastructure/Jobs/NomadJob.cs
+++ b/src/Infrastructure/Jobs/NomadJob.cs
@@ -64,7 +64,7 @@ public class NomadJob : Job
                         Stop();
                     }
                     catch (Exception) { }
-                    _status = JobStatus.Stopped;
+                    _status = JobStatus.Canceled;
                 });
             }
         }

--- a/tests/Hippo.FunctionalTests/TestBase.cs
+++ b/tests/Hippo.FunctionalTests/TestBase.cs
@@ -213,7 +213,7 @@ public class NullJobFactory : IJobFactory
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                _status = JobStatus.Stopped;
+                _status = JobStatus.Canceled;
             }
             else
             {


### PR DESCRIPTION
To better clarify the difference between a "Completed" and a "Stopped" job,
re-naming "Stopped" to "Canceled" helps better convey that calling
".Stop" on a Job should return "Completed" rather than "Canceled".

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>