### PR TITLE
fix storage ID regex

### DIFF
--- a/src/Application/Apps/Commands/CreateAppCommandValidator.cs
+++ b/src/Application/Apps/Commands/CreateAppCommandValidator.cs
@@ -11,7 +11,7 @@ public class CreateAppCommandValidator : AbstractValidator<CreateAppCommand>
 
     private readonly Regex validName = new Regex("^[a-zA-Z0-9-_]*$");
 
-    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9.-_/]*$");
+    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9-_./]*$");
 
     public CreateAppCommandValidator(IApplicationDbContext context)
     {

--- a/src/Application/Apps/Commands/UpdateAppCommandValidator.cs
+++ b/src/Application/Apps/Commands/UpdateAppCommandValidator.cs
@@ -11,7 +11,7 @@ public class UpdateAppCommandValidator : AbstractValidator<UpdateAppCommand>
 
     private readonly Regex validName = new Regex("^[a-zA-Z0-9-_]*$");
 
-    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9.-_/]*$");
+    private readonly Regex validStorageId = new Regex("^[a-zA-Z0-9-_./]*$");
 
     public UpdateAppCommandValidator(IApplicationDbContext context)
     {

--- a/tests/Hippo.FunctionalTests/Application/Apps/Commands/CreateAppTests.cs
+++ b/tests/Hippo.FunctionalTests/Application/Apps/Commands/CreateAppTests.cs
@@ -25,6 +25,8 @@ public class CreateAccountTests : TestBase
     [InlineData("bar", "bar")]
     [InlineData("name-with-hyphens", "bar")]
     [InlineData("name_with_underscores", "bar")]
+    [InlineData("storage-id-with-hyphens", "my-app")]
+    [InlineData("storage-id-with-underscores", "my_app")]
     [InlineData("storage-id-with-slash", "bacongobbler/myapp")]
     [InlineData("storage-id-with-dot", "github.com/bacongobbler/myapp")]
     public void ShouldCreateApp(string name, string storageId)


### PR DESCRIPTION
The previous regular expression would not allow hyphens in the storage
ID.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>