### PR TITLE
handle enum string conversions

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Serialization;
 using FluentValidation.AspNetCore;
 using Hippo.Application;
 using Hippo.Application.Common.Interfaces;
@@ -26,7 +27,12 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddHealthChecks()
             .AddDbContextCheck<ApplicationDbContext>();
 
-builder.Services.AddControllersWithViews().AddFluentValidation();
+builder.Services.AddControllersWithViews()
+    .AddJsonOptions(opt =>
+    {
+        opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    })
+    .AddFluentValidation();
 
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 


### PR DESCRIPTION
The rust client sends "0" as the value, as generated by the openapi project. We need to tell .NET that it should accept string values for enum conversions.

closes https://github.com/deislabs/hippo-cli/issues/120