### PR TITLE
Dispatch domain events from a behaviour pipeline

### DIFF
--- a/src/Application/Common/Behaviours/DomainEventPublishingBehaviour.cs
+++ b/src/Application/Common/Behaviours/DomainEventPublishingBehaviour.cs
@@ -1,0 +1,42 @@
+using Hippo.Application.Common.Interfaces;
+using Hippo.Core.Common;
+using MediatR.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace CleanArchitecture.Application.Common.Behaviours
+{
+    public class DomainEventPublishingBehaviour<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse> where TRequest : notnull
+    {
+        private readonly ILogger _logger;
+        private readonly IApplicationDbContext _dbContext;
+        private readonly IDomainEventService _domainEventService;
+
+        public DomainEventPublishingBehaviour(
+            ILogger<TRequest> logger,
+            IApplicationDbContext dbContext,
+            IDomainEventService domainEventService)
+        {
+            _logger = logger;
+            _dbContext = dbContext;
+            _domainEventService = domainEventService;
+        }
+
+        public async Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var domainEventEntity = _dbContext.ChangeTracker.Entries<IHasDomainEvent>()
+                                                     .Select(x => x.Entity.DomainEvents)
+                                                     .SelectMany(x => x)
+                                                     .Where(domainEvent => !domainEvent.IsPublished)
+                                                     .FirstOrDefault();
+                if (domainEventEntity == null) break;
+
+                domainEventEntity.IsPublished = true;
+                await _domainEventService.Publish(domainEventEntity);
+
+                _logger.LogInformation("Published event: {Name}", domainEventEntity.GetType().Name);
+            }
+        }
+    }
+}

--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Hippo.Core.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Hippo.Application.Common.Interfaces;
 
@@ -14,6 +15,8 @@ public interface IApplicationDbContext
     DbSet<EnvironmentVariable> EnvironmentVariables { get; }
 
     DbSet<Revision> Revisions { get; }
+
+    ChangeTracker ChangeTracker { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -14,27 +14,21 @@ public class ApplicationDbContext : IdentityDbContext<Account>, IApplicationDbCo
 
     private readonly IDateTime _dateTime;
 
-    private readonly IDomainEventService _domainEventService;
-
     public ApplicationDbContext(
             DbContextOptions<ApplicationDbContext> options,
             ICurrentUserService currentUserService,
-            IDateTime dateTime,
-            IDomainEventService domainEventService) : base(options)
+            IDateTime dateTime) : base(options)
     {
         _currentUserService = currentUserService;
         _dateTime = dateTime;
-        _domainEventService = domainEventService;
     }
 
     public ApplicationDbContext(
             ICurrentUserService currentUserService,
-            IDateTime dateTime,
-            IDomainEventService domainEventService)
+            IDateTime dateTime)
     {
         _currentUserService = currentUserService;
         _dateTime = dateTime;
-        _domainEventService = domainEventService;
     }
 
     public DbSet<App> Apps => Set<App>();
@@ -72,8 +66,6 @@ public class ApplicationDbContext : IdentityDbContext<Account>, IApplicationDbCo
 
         var result = await base.SaveChangesAsync(cancellationToken);
 
-        await DispatchEvents(events);
-
         return result;
     }
 
@@ -82,14 +74,5 @@ public class ApplicationDbContext : IdentityDbContext<Account>, IApplicationDbCo
         builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         base.OnModelCreating(builder);
-    }
-
-    private async Task DispatchEvents(DomainEvent[] events)
-    {
-        foreach (var @event in events)
-        {
-            @event.IsPublished = true;
-            await _domainEventService.Publish(@event);
-        }
     }
 }

--- a/src/Infrastructure/Data/PostgresqlDbContext.cs
+++ b/src/Infrastructure/Data/PostgresqlDbContext.cs
@@ -7,7 +7,7 @@ namespace Hippo.Infrastructure.Data;
 public class PostgresqlDbContext : ApplicationDbContext
 {
     public IConfiguration Configuration { get; }
-    public PostgresqlDbContext(IConfiguration configuration, ICurrentUserService currentUserService, IDateTime dateTime, IDomainEventService domainEventService) : base(currentUserService, dateTime, domainEventService)
+    public PostgresqlDbContext(IConfiguration configuration, ICurrentUserService currentUserService, IDateTime dateTime) : base(currentUserService, dateTime)
     {
         Configuration = configuration;
     }

--- a/src/Infrastructure/Data/SqliteDbContext.cs
+++ b/src/Infrastructure/Data/SqliteDbContext.cs
@@ -8,7 +8,7 @@ public class SqliteDbContext : ApplicationDbContext
 {
     public IConfiguration Configuration { get; }
 
-    public SqliteDbContext(IConfiguration configuration, ICurrentUserService currentUserService, IDateTime dateTime, IDomainEventService domainEventService) : base(currentUserService, dateTime, domainEventService)
+    public SqliteDbContext(IConfiguration configuration, ICurrentUserService currentUserService, IDateTime dateTime) : base(currentUserService, dateTime)
     {
         Configuration = configuration;
     }


### PR DESCRIPTION
This allows one to test the dispatching of domain events from within the application layer, without the reliance of a data store. It also decouples the domain event system from the storage layer.