### PR TITLE
Fix: fire ModifiedEvent<Channel>

### DIFF
--- a/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
+++ b/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
@@ -38,7 +38,13 @@ public class RevisionCreatedEventHandler : INotificationHandler<DomainEventNotif
         {
             if (channel.RevisionSelectionStrategy == ChannelRevisionSelectionStrategy.UseRangeRule)
             {
-                channel.ActiveRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
+                var activeRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
+                if (activeRevision != channel.ActiveRevision)
+                {
+                    _logger.LogInformation($"Channel {channel.Id} changed its active revision to {activeRevision?.Id}");
+                    channel.ActiveRevision = activeRevision;
+                    channel.DomainEvents.Add(new ModifiedEvent<Channel>(channel));
+                }
             }
         }
 

--- a/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
+++ b/src/Application/Revisions/EventHandlers/RevisionCreatedEventHandler.cs
@@ -39,9 +39,9 @@ public class RevisionCreatedEventHandler : INotificationHandler<DomainEventNotif
             if (channel.RevisionSelectionStrategy == ChannelRevisionSelectionStrategy.UseRangeRule)
             {
                 var activeRevision = RevisionRangeRule.Parse(channel.RangeRule).Match(channel.App.Revisions);
-                if (activeRevision != channel.ActiveRevision)
+                if (activeRevision is not null && activeRevision != channel.ActiveRevision)
                 {
-                    _logger.LogInformation($"Channel {channel.Id} changed its active revision to {activeRevision?.Id}");
+                    _logger.LogInformation($"Channel {channel.Id} changed its active revision to {activeRevision.Id}");
                     channel.ActiveRevision = activeRevision;
                     channel.DomainEvents.Add(new ModifiedEvent<Channel>(channel));
                 }


### PR DESCRIPTION
When the channel's `ActiveRevision` changes, we need to fire off a
ModifiedEvent<Channel> so that hippo can properly update the job
scheduler.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>