### PR TITLE
improve production logging

### DIFF
--- a/src/Web/appsettings.Development.json
+++ b/src/Web/appsettings.Development.json
@@ -2,11 +2,8 @@
     "Logging": {
         "LogLevel": {
             "Default": "Information",
-            "Microsoft": "Information",
             "Microsoft.AspNetCore": "Warning",
             "Microsoft.EntityFrameworkCore": "Warning",
-            "System": "Information",
-
             "Hippo": "Debug"
         }
     },

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -2,8 +2,7 @@
     "Logging": {
         "LogLevel": {
             "Default": "Warning",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
+            "Hippo": "Information"
         }
     },
     "Jwt": {


### PR DESCRIPTION
Hippo would not report much other than fail messages. In production,
we'd like to log everything other than warnings and error messages.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>