### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,9 +21,6 @@ RUN curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bind
 ARG SPIN_VERSION="v0.1.0"
 RUN curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin /usr/local/bin/
 
-# Install yo-wasm
-RUN su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && npm install -g yo && npm install -g generator-wasm"
-
 # Install Rust
 RUN su vscode -c "umask 0002 && cd /tmp && mkdir rust && cd rust && curl -fsSLo install_rust.sh https://sh.rustup.rs && chmod +x ./install_rust.sh  && ./install_rust.sh -y -t wasm32-wasi"
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends gcc gcc-multilib

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 // It should match the value of the ENV VAR DEVCONTAINER_VERSION in build-devcontainer.yml
 {
     "name": "Hippo",
-    "image": "ghcr.io/deislabs/hippo-dev:v1.0.2",
+    "image": "ghcr.io/deislabs/hippo-dev:v1.1.0",
     // Set *default* container specific settings.json values on container create.
     "settings": {
         "remote.autoForwardPorts": false
@@ -17,15 +17,13 @@
     "containerEnv": {
         "BINDLE_URL": "http://localhost:8080/v1",
         "HIPPO_URL": "https://localhost:5309",
-        "GLOBAL_AGENT_FORCE_GLOBAL_AGENT": "false",
         // This places bindle server data in the workspace so that state is retained across multiple invocations of the bindle server 
         // Delete this folder and src/Web/hippo.db.* files to reset Hippo
         "BINDLE_DIRECTORY" : "${containerWorkspaceFolder}/bindleserver/data"
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // 5309 is the Hippo HTTPS Port.
-    // 32768-32770 are the first three ports that are used by applications launched from Hippo's local scheduler. Normally this would not be accessed directly but through the proxy endpoint on port 5002, however in GitHub codespaces 
-    // this will not work as Headers don't seem to be forwarded by the Codespaces proxy.
+    // 5309 is the Hippo HTTPS port.
+    // 8080 is the Bindle HTTP port.
     "forwardPorts": [
         5309,
         8080
@@ -33,7 +31,7 @@
     "remoteUser": "vscode",
     "updateRemoteUserUID": false,
     // restore and build the application, add the dev cert. 
-    "postCreateCommand": "cd src/Web && dotnet restore && npm run build && dotnet build && dotnet dev-certs https",
+    "postCreateCommand": "cd src/Web && dotnet restore && dotnet build && dotnet dev-certs https",
     "portsAttributes": {
         "5309": {
             "label": "Hippo HTTPS Port",

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -11,7 +11,7 @@ jobs:
     name: Push devcontainer/codespaces image to GitHub Package Registry
     runs-on: ubuntu-latest
     env:
-      DEVCONTAINER_VERSION: v1.0.2
+      DEVCONTAINER_VERSION: v1.1.0
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
- remove yo-wasm
- bump devcontainer image tag
- fix postCreateCommand (`npm install` is not required - `dotnet build` builds the client app for us)