### PR TITLE
Downgrade hippo-dev to match hippo version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 // It should match the value of the ENV VAR DEVCONTAINER_VERSION in build-devcontainer.yml
 {
     "name": "Hippo",
-    "image": "ghcr.io/deislabs/hippo-dev:v1.1.0",
+    "image": "ghcr.io/deislabs/hippo-dev:v0.6.2",
     // Set *default* container specific settings.json values on container create.
     "settings": {
         "remote.autoForwardPorts": false

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -11,7 +11,7 @@ jobs:
     name: Push devcontainer/codespaces image to GitHub Package Registry
     runs-on: ubuntu-latest
     env:
-      DEVCONTAINER_VERSION: v1.1.0
+      DEVCONTAINER_VERSION: v0.6.2
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This makes hippo-dev match `ghcr.io/deislabs/hippo` as well as the current hippo version. That way the developer knows they have the right dev container version.