### PR TITLE
change hippofactory.local to hippo.localdomain

### DIFF
--- a/src/Application/Common/Config/HippoConfig.cs
+++ b/src/Application/Common/Config/HippoConfig.cs
@@ -2,5 +2,5 @@ namespace Hippo.Application.Common.Config;
 
 public class HippoConfig
 {
-    public string PlatformDomain { get; set; } = "hippofactory.io";
+    public string PlatformDomain { get; set; } = "hippo.localdomain";
 }

--- a/src/Web/appsettings.Development.json
+++ b/src/Web/appsettings.Development.json
@@ -13,7 +13,7 @@
         "Audience": "localhost"
     },
     "Hippo" : {
-        "PlatformDomain": "hippofactory.local"
+        "PlatformDomain": "hippo.localdomain"
     },
     "Scheduler": {
 	    "Driver": "local"


### PR DESCRIPTION
.local is reserved on MacOS for mDNS

https://blog.scottlowe.org/2006/01/04/mac-os-x-and-local-domains/

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>