### PR TITLE
display password mismatch and minlength errors

### DIFF
--- a/src/Web/ClientApp/src/app/components/account/register/register.component.html
+++ b/src/Web/ClientApp/src/app/components/account/register/register.component.html
@@ -30,6 +30,10 @@
 				class="input" placeholder="make it strong!" />
 			<div *ngIf="submitted && f['password'].errors" class="help is-danger">
 				<div *ngIf="f['password'].errors['required']">Password is required.</div>
+				<div *ngIf="f['password'].errors['minlength']">Password must be at least 8 characters long.</div>
+			</div>
+			<div *ngIf="submitted && registrationForm.errors?.['mustMatch']" class="help is-danger">
+				Passwords must match.
 			</div>
 		</div>
 	</div>
@@ -42,6 +46,10 @@
 				class="input" placeholder="make it strong!" />
 			<div *ngIf="submitted && f['passwordConfirm'].errors" class="help is-danger">
 				<div *ngIf="f['passwordConfirm'].errors['required']">Password is required.</div>
+				<div *ngIf="f['passwordConfirm'].errors['minlength']">Password must be at least 8 characters long.</div>
+			</div>
+			<div *ngIf="submitted && registrationForm.errors?.['mustMatch']" class="help is-danger">
+				Passwords must match.
 			</div>
 		</div>
 	</div>

--- a/src/Web/ClientApp/src/app/components/account/register/register.component.html
+++ b/src/Web/ClientApp/src/app/components/account/register/register.component.html
@@ -30,7 +30,7 @@
 				class="input" placeholder="make it strong!" />
 			<div *ngIf="submitted && f['password'].errors" class="help is-danger">
 				<div *ngIf="f['password'].errors['required']">Password is required.</div>
-				<div *ngIf="f['password'].errors['minlength']">Password must be at least 8 characters long.</div>
+				<div *ngIf="f['password'].errors['minlength']">Password must be at least 6 characters long.</div>
 			</div>
 			<div *ngIf="submitted && registrationForm.errors?.['mustMatch']" class="help is-danger">
 				Passwords must match.
@@ -46,7 +46,7 @@
 				class="input" placeholder="make it strong!" />
 			<div *ngIf="submitted && f['passwordConfirm'].errors" class="help is-danger">
 				<div *ngIf="f['passwordConfirm'].errors['required']">Password is required.</div>
-				<div *ngIf="f['passwordConfirm'].errors['minlength']">Password must be at least 8 characters long.</div>
+				<div *ngIf="f['passwordConfirm'].errors['minlength']">Password must be at least 6 characters long.</div>
 			</div>
 			<div *ngIf="submitted && registrationForm.errors?.['mustMatch']" class="help is-danger">
 				Passwords must match.

--- a/src/Web/ClientApp/src/app/components/account/register/register.component.ts
+++ b/src/Web/ClientApp/src/app/components/account/register/register.component.ts
@@ -31,11 +31,11 @@ export class RegisterComponent implements OnInit {
 				]),
 				password: new FormControl('', [
 					Validators.required,
-					Validators.minLength(8),
+					Validators.minLength(6),
 				]),
 				passwordConfirm: new FormControl('', [
 					Validators.required,
-					Validators.minLength(8)
+					Validators.minLength(6)
 				])
 			},
 			MustMatch('password', 'passwordConfirm'),


### PR DESCRIPTION
Fixes an issue where the password mismatch and minimum length requirement errors would not be displayed.

https://github.com/deislabs/hippo/pull/707 presents server-side errors, but we're performing some client-side validation as well.

closes #673.