### PR TITLE
remove "storage ID" from UI

### DIFF
--- a/src/Web/ClientApp/src/app/components/application/new/new.component.html
+++ b/src/Web/ClientApp/src/app/components/application/new/new.component.html
@@ -18,22 +18,6 @@
 				<div class="panel-block">
 					<div class="control">
 						<label class="label">Name</label>
-						<div class="control has-icons-left has-icons-right">
-							<input type="text" formControlName="name"
-								[ngClass]="{ 'is-danger': submitted && f['name'].errors }"
-								class="input" placeholder="Name your application" />
-							<div *ngIf="submitted && f['name'].errors" class="help is-danger">
-								<div *ngIf="f['name'].errors['required']">Name is required.</div>
-							</div>
-							<span class="icon is-left">
-								<fa-icon [icon]="faTable"></fa-icon>
-							</span>
-						</div>
-					</div>
-				</div>
-				<div class="panel-block">
-					<div class="control">
-						<label class="label">Choose storage</label>
 						<div class="control has-icons-left"
 						[ngClass]="{ 'is-loading': storageListLoading }">
 							<input type="text"
@@ -41,7 +25,7 @@
 							#storageSearchInput
 							(ngModelChange)="searchStorages($event)"
 							[ngModelOptions]="{standalone: true}"
-								class="input" placeholder="Storage ID" />
+								class="input" placeholder="Name" />
 							<span class="icon is-left">
 								<fa-icon [icon]="faSearch"></fa-icon>
 							</span>

--- a/src/Web/ClientApp/src/app/components/application/new/new.component.ts
+++ b/src/Web/ClientApp/src/app/components/application/new/new.component.ts
@@ -32,9 +32,6 @@ export class NewComponent implements OnInit {
   ngOnInit() {
     this.appForm = new FormGroup({
       name: new FormControl('', [
-        Validators.required
-      ]),
-      storageId: new FormControl('', [
         Validators.required,
       ])
     });
@@ -80,7 +77,7 @@ export class NewComponent implements OnInit {
   selectStorage(storage: string) {
     this.selectedStorage = storage;
     this.appForm.patchValue({
-      storageId: storage
+      name: storage
    });
   }
 
@@ -94,7 +91,7 @@ export class NewComponent implements OnInit {
     }
 
     this.loading = true;
-    this.appService.apiAppPost({ name: this.f['name'].value, storageId: this.f['storageId'].value })
+    this.appService.apiAppPost({ name: this.f['name'].value, storageId: this.f['name'].value })
     .subscribe({
       // TODO: navigate to registration confirmation page
       next: () => this.router.navigate(['/app']),


### PR DESCRIPTION
The application name and the storage ID are two VERY similar concepts. So instead we'll present it as the "name" in the UI, then store it in the API as both the "name" and the "storage ID".

We might consider removing the "name" field from Hippo's API, but for now we should just hide it.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>