### PR TITLE
cut release on any tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Create a Release
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+-preview'
+    - "*"
 
 jobs:
   release:


### PR DESCRIPTION
the current release workflow will not cut a release if I use the Semantic Versioning build number or pre-release system. Instead it relies on a `-preview` tag, when normally we follow the release candidate (`-rc.1`) pattern for versioning.