### PR TITLE
Introduce API versioning

### DIFF
--- a/src/Web/Api/ApiControllerBase.cs
+++ b/src/Web/Api/ApiControllerBase.cs
@@ -6,6 +6,7 @@ namespace Hippo.Web.Api;
 
 [Area("API")]
 [Route("api/[controller]")]
+[ApiVersion("0.1")]
 [ApiController]
 [ApiExceptionFilter]
 public abstract class ApiControllerBase : Controller

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -9,6 +9,7 @@ using Hippo.Infrastructure.Identity;
 using Hippo.Web.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -54,6 +55,14 @@ builder.Services.AddAuthentication().AddCookie().AddJwtBearer(cfg =>
         cfg.SaveToken = true;
     }
 );
+
+builder.Services.AddApiVersioning(options =>
+{
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.DefaultApiVersion = new ApiVersion(0, 1);
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = new HeaderApiVersionReader("Api-Version");
+});
 
 builder.Services.AddSwaggerGen(c =>
 {

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -60,6 +60,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />


### PR DESCRIPTION
Clients can now understand what API versions Hippo is serving at any point. Clients can point to specific API versions by adding the `Api-Version` header to their requests. As of right now the first API version is 0.1, which is assumed by default.

A client implementation is still required. Clients should read the `api-supported-versions` header to determine compatibility with the server.

See https://www.telerik.com/blogs/your-guide-rest-api-versioning-aspnet-core for more details.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>