### PR TITLE
remove duplicate domain

### DIFF
--- a/src/Web/appsettings.Development.json
+++ b/src/Web/appsettings.Development.json
@@ -12,9 +12,6 @@
 		"Issuer": "localhost",
 		"Audience": "localhost"
 	},
-	"Hippo" : {
-		"PlatformDomain": "hippo.localdomain"
-	},
 	"Database": {
 		"Driver": "sqlite"
 	},


### PR DESCRIPTION
hippo.localdomain is the default platform domain.