### PR TITLE
Run `npm run publish` on build

### DIFF
--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -38,8 +38,7 @@
 		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm install" />
 	</Target>
 
-	<Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm install" />
+	<Target Name="PublishRunWebpack" BeforeTargets="Build" DependsOnTargets="NpmInstall">
 		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm run publish" />
 
 		<!-- Include the newly-built files in the publish output -->


### PR DESCRIPTION
This enables `dotnet run`/`dotnet watch` to re-run `npm run publish`. Right now it only runs if `dotnet publish` is invoked.