### PR TITLE
ref(BindleService): add Description to RevisionComponent

### DIFF
--- a/src/Application/Apps/Commands/CreateAppCommandValidator.cs
+++ b/src/Application/Apps/Commands/CreateAppCommandValidator.cs
@@ -28,7 +28,7 @@ public class CreateAppCommandValidator : AbstractValidator<CreateAppCommand>
 
         RuleFor(a => a.StorageId)
             .NotEmpty().WithMessage("Storage ID is required.")
-            .MustAsync(ExistInBindleServer).WithMessage("Storage ID not found")
+            .MustAsync(ExistInBindleServer).WithMessage("Storage ID not found in bindle server")
             .MaximumLength(200)
             .Matches(validStorageId);
 

--- a/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
@@ -11,5 +11,8 @@ public class RevisionComponent
     public string Id { get; set; } = string.Empty;
 
     [Required]
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
     public RevisionComponentTrigger? Trigger { get; set; }
 }


### PR DESCRIPTION
+ This change adds Description to RevisionComponent to help
resolve an error being thrown when parsing a spin toml parcel
from a bindle.
+ This resolves the 500 I was seeing when trying to create an app
+ Also updated the storage id not found error message

Signed-off-by: Michelle Dhanani <michelle@fermyon.com>