### PR TITLE
Feature/make non spa proxy launch setting

### DIFF
--- a/src/Web/ClientApp/angular.json
+++ b/src/Web/ClientApp/angular.json
@@ -71,7 +71,8 @@
 							"browserTarget": "ClientApp:build:production"
 						},
 						"development": {
-							"browserTarget": "ClientApp:build:development"
+							"browserTarget": "ClientApp:build:development",
+							"proxyConfig": "proxy.conf.js"
 						}
 					},
 					"defaultConfiguration": "development"

--- a/src/Web/ClientApp/proxy.conf.js
+++ b/src/Web/ClientApp/proxy.conf.js
@@ -1,0 +1,19 @@
+const { env } = require('process');
+
+const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
+  env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'https://localhost:5309';
+
+const PROXY_CONFIG = [
+  {
+    context: [
+      "/api",
+   ],
+    target: target,
+    secure: false,
+    headers: {
+      Connection: 'Keep-Alive'
+    }
+  }
+]
+
+module.exports = PROXY_CONFIG;

--- a/src/Web/Properties/launchSettings.json
+++ b/src/Web/Properties/launchSettings.json
@@ -1,6 +1,16 @@
 ﻿{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "no-proxy": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "applicationUrl": "https://localhost:5309",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "hippo-server": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -10,16 +20,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
-      }
-    },
-    "no-proxy": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "launchBrowser": true,
-      "launchUrl": "",
-      "applicationUrl": "https://localhost:5309",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/src/Web/Properties/launchSettings.json
+++ b/src/Web/Properties/launchSettings.json
@@ -8,6 +8,17 @@
       "launchUrl": "",
       "applicationUrl": "https://localhost:5309",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
+      }
+    },
+    "no-proxy": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "applicationUrl": "https://localhost:5309",
+      "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -14,6 +14,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<SpaRoot>ClientApp</SpaRoot>
+		<SpaProxyServerUrl>http://localhost:44467</SpaProxyServerUrl>
+		<SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -21,11 +23,6 @@
 		<Content Remove="$(SpaRoot)\**" />
 		<None Remove="$(SpaRoot)\**" />
 		<None Include="$(SpaRoot)\**" Exclude="$(SpaRoot)\node_modules\**" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<!-- Extends watching group to include Angular app changes -->
-		<Watch Include="$(SpaRoot)\**\*" Exclude="$(SpaRoot)\node_modules\**\*;$(SpaRoot)\**\*.spec.ts" />
 	</ItemGroup>
 
 	<Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('$(SpaRoot)\node_modules')">
@@ -38,7 +35,12 @@
 		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm install" />
 	</Target>
 
-	<Target Name="PublishRunWebpack" BeforeTargets="Build" DependsOnTargets="NpmInstall">
+	<Target Name="NpmRunBuild" AfterTargets="NpmInstall">
+		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm run build"/>
+	</Target>
+
+	<Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
+		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm install" />
 		<Exec WorkingDirectory="$(SpaRoot)\" Command="npm run publish" />
 
 		<!-- Include the newly-built files in the publish output -->
@@ -59,6 +61,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
+		<PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.5" />


### PR DESCRIPTION
Added back the proxy, but created a new profile that is run by default when you `dotnet run` that runs without proxy