### PR TITLE
ref(nomadjob): update nomad address syntax

### DIFF
--- a/src/Infrastructure/Services/NomadJobService.cs
+++ b/src/Infrastructure/Services/NomadJobService.cs
@@ -169,7 +169,7 @@ public class NomadJobService : IJobService
             Config = new Dictionary<string, object>
             {
                 { "command", nomadJob.spinBinaryPath },
-                { "args", new List<string> { "up", "--listen", "[${NOMAD_IP_http}]:${NOMAD_PORT_http}", "--follow-all", "--bindle", nomadJob.BindleId } }
+                { "args", new List<string> { "up", "--listen", "${NOMAD_IP_http}:${NOMAD_PORT_http}", "--follow-all", "--bindle", nomadJob.BindleId } }
             }
         };
     }


### PR DESCRIPTION
I was getting an "invalid socket address" error when deploying spin applications. This change fixes that issue.

https://github.com/fermyon/spin/pull/507#issuecomment-1132928254

Signed-off-by: Michelle Dhanani <michelle@fermyon.com>