### PR TITLE
fix(NomadJobService.cs): adjust the traefik entryPoints annotation on a Nomad job

### DIFF
--- a/src/Infrastructure/Services/NomadJobService.cs
+++ b/src/Infrastructure/Services/NomadJobService.cs
@@ -136,7 +136,7 @@ public class NomadJobService : IJobService
             {
                 "traefik.enable=true",
                 "traefik.http.routers." + nomadJob.Id + @".rule=Host(`" + nomadJob.Domain + "`)",
-                "traefik.http.routers." + nomadJob.Id + @".tls.entryPoints=" + entrypoint,
+                "traefik.http.routers." + nomadJob.Id + @".entryPoints=" + entrypoint,
                 "traefik.http.routers." + nomadJob.Id + @".tls=false",
                 "traefik.http.routers." + nomadJob.Id + @".tls.certresolver=" + certresolver,
                 "traefik.http.routers." + nomadJob.Id + @".tls.domains[0].main=" + nomadJob.Domain + ""


### PR DESCRIPTION
* the `entryPoints` key/value should go on the name of the service directly