### PR TITLE
implement alternative registration modes: "Open", "Closed", and "AdministratorOnly"

### DIFF
--- a/src/Application/Accounts/Commands/CreateAccountCommand.cs
+++ b/src/Application/Accounts/Commands/CreateAccountCommand.cs
@@ -1,5 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using Hippo.Application.Common.Config;
+using Hippo.Application.Common.Exceptions;
 using Hippo.Application.Common.Interfaces;
+using Hippo.Application.Common.Security;
+using Hippo.Core.Enums;
 using MediatR;
 
 namespace Hippo.Application.Accounts.Commands;
@@ -15,17 +19,37 @@ public class CreateAccountCommand : IRequest<string>
 
 public class CreateAccountCommandHandler : IRequestHandler<CreateAccountCommand, string>
 {
+    private readonly ICurrentUserService _currentUserService;
+    private readonly HippoConfig _hippoConfig;
     private readonly IIdentityService _identityService;
 
-    public CreateAccountCommandHandler(IIdentityService identityService)
+    public CreateAccountCommandHandler(ICurrentUserService currentUserService, HippoConfig hippoConfig, IIdentityService identityService)
     {
+        _currentUserService = currentUserService;
+        _hippoConfig = hippoConfig;
         _identityService = identityService;
     }
 
     public async Task<string> Handle(CreateAccountCommand request, CancellationToken cancellationToken)
     {
-        var result = await _identityService.CreateUserAsync(request.UserName, request.Password);
+        switch (_hippoConfig.RegistrationMode)
+        {
+            case RegistrationMode.Closed:
+                {
+                    throw new ForbiddenAccessException("registration closed");
+                }
 
+            case RegistrationMode.AdministratorOnly:
+                {
+                    if (_currentUserService.UserId is null || !await _identityService.IsInRoleAsync(_currentUserService.UserId, UserRole.Administrator))
+                    {
+                        throw new ForbiddenAccessException("only administrators are allowed to register new accounts");
+                    }
+                    break;
+                }
+        }
+
+        var result = await _identityService.CreateUserAsync(request.UserName, request.Password);
         return result.UserId;
     }
 }

--- a/src/Application/Apps/Commands/PurgeAppsCommand.cs
+++ b/src/Application/Apps/Commands/PurgeAppsCommand.cs
@@ -6,8 +6,8 @@ using MediatR;
 
 namespace Hippo.Application.Apps.Commands;
 
-[Authorize(Roles = "Administrator")]
-[Authorize(Policy = "CanPurge")]
+[Authorize(Roles = UserRole.Administrator)]
+[Authorize(Policy = UserPolicy.CanPurge)]
 public class PurgeAppsCommand : IRequest { }
 
 public class PurgeAppsCommandHandler : IRequestHandler<PurgeAppsCommand>

--- a/src/Application/Certificates/Commands/PurgeCertificatesCommand.cs
+++ b/src/Application/Certificates/Commands/PurgeCertificatesCommand.cs
@@ -6,8 +6,8 @@ using MediatR;
 
 namespace Hippo.Application.Certificates.Commands;
 
-[Authorize(Roles = "Administrator")]
-[Authorize(Policy = "CanPurge")]
+[Authorize(Roles = UserRole.Administrator)]
+[Authorize(Policy = UserPolicy.CanPurge)]
 public class PurgeCertificatesCommand : IRequest { }
 
 public class PurgeCertificatesCommandHandler : IRequestHandler<PurgeCertificatesCommand>

--- a/src/Application/Channels/Commands/PurgeChannelsCommand.cs
+++ b/src/Application/Channels/Commands/PurgeChannelsCommand.cs
@@ -6,8 +6,8 @@ using MediatR;
 
 namespace Hippo.Application.Channels.Commands;
 
-[Authorize(Roles = "Administrator")]
-[Authorize(Policy = "CanPurge")]
+[Authorize(Roles = UserRole.Administrator)]
+[Authorize(Policy = UserPolicy.CanPurge)]
 public class PurgeChannelsCommand : IRequest { }
 
 public class PurgeChannelsCommandHandler : IRequestHandler<PurgeChannelsCommand>

--- a/src/Application/Common/Config/HippoConfig.cs
+++ b/src/Application/Common/Config/HippoConfig.cs
@@ -1,6 +1,19 @@
+using Hippo.Core.Enums;
+
 namespace Hippo.Application.Common.Config;
 
 public class HippoConfig
 {
     public string PlatformDomain { get; set; } = "hippo.localdomain";
+
+    public RegistrationMode RegistrationMode { get; set; } = RegistrationMode.Open;
+
+    public List<UserCredentials> Administrators { get; set; } = new List<UserCredentials>();
+}
+
+public class UserCredentials
+{
+    public string Username { get; set; } = String.Empty;
+
+    public string Password { get; set; } = String.Empty;
 }

--- a/src/Application/Common/Exceptions/ForbiddenAccessException.cs
+++ b/src/Application/Common/Exceptions/ForbiddenAccessException.cs
@@ -2,5 +2,12 @@
 
 public class ForbiddenAccessException : Exception
 {
-    public ForbiddenAccessException() : base() { }
+    public ForbiddenAccessException() : base()
+    {
+    }
+
+    public ForbiddenAccessException(string message)
+        : base(message)
+    {
+    }
 }

--- a/src/Application/Common/Security/UserPolicy.cs
+++ b/src/Application/Common/Security/UserPolicy.cs
@@ -1,0 +1,12 @@
+namespace Hippo.Application.Common.Security;
+
+/// <summary>
+/// The policies available for user accounts
+/// </summary>
+public static class UserPolicy
+{
+    /// <summary>
+    /// Can purge resources
+    /// </summary>
+    public const string CanPurge = "CanPurge";
+}

--- a/src/Application/Common/Security/UserRole.cs
+++ b/src/Application/Common/Security/UserRole.cs
@@ -1,0 +1,12 @@
+namespace Hippo.Application.Common.Security;
+
+/// <summary>
+/// The roles available for user accounts
+/// </summary>
+public static class UserRole
+{
+    /// <summary>
+    /// Administrator account (full access)
+    /// </summary>
+    public const string Administrator = "Administrator";
+}

--- a/src/Application/EnvironmentVariables/Commands/PurgeEnvironmentVariablesCommand.cs
+++ b/src/Application/EnvironmentVariables/Commands/PurgeEnvironmentVariablesCommand.cs
@@ -6,8 +6,8 @@ using MediatR;
 
 namespace Hippo.Application.EnvironmentVariables.Commands;
 
-[Authorize(Roles = "Administrator")]
-[Authorize(Policy = "CanPurge")]
+[Authorize(Roles = UserRole.Administrator)]
+[Authorize(Policy = UserPolicy.CanPurge)]
 public class PurgeEnvironmentVariablesCommand : IRequest { }
 
 public class PurgeEnvironmentVariablesCommandHandler : IRequestHandler<PurgeEnvironmentVariablesCommand>

--- a/src/Application/Revisions/Commands/PurgeRevisionsCommand.cs
+++ b/src/Application/Revisions/Commands/PurgeRevisionsCommand.cs
@@ -6,8 +6,8 @@ using MediatR;
 
 namespace Hippo.Application.Revisions.Commands;
 
-[Authorize(Roles = "Administrator")]
-[Authorize(Policy = "CanPurge")]
+[Authorize(Roles = UserRole.Administrator)]
+[Authorize(Policy = UserPolicy.CanPurge)]
 public class PurgeRevisionsCommand : IRequest { }
 
 public class PurgeRevisionsCommandHandler : IRequestHandler<PurgeRevisionsCommand>

--- a/src/Core/Enums/ChannelRevisionSelectionStrategy.cs
+++ b/src/Core/Enums/ChannelRevisionSelectionStrategy.cs
@@ -12,5 +12,5 @@ public enum ChannelRevisionSelectionStrategy
     /// <summary>
     /// Use a specific revision version for the channel
     /// </summary>
-    UseSpecifiedRevision = 1,
+    UseSpecifiedRevision = 1
 }

--- a/src/Core/Enums/RegistrationMode.cs
+++ b/src/Core/Enums/RegistrationMode.cs
@@ -1,0 +1,20 @@
+namespace Hippo.Core.Enums;
+
+/// <summary>
+/// The mode to use to when registering new accounts
+/// </summary>
+public enum RegistrationMode
+{
+    /// <summary>
+    /// Allows account registration IFF you are logged in as an administrator.
+    /// </summary>
+    AdministratorOnly,
+    /// <summary>
+    /// Disables account registration.
+    /// </summary>
+    Closed,
+    /// <summary>
+    /// Enables open account registration (anyone with the URL can register an account). This is the default.
+    /// </summary>
+    Open
+}

--- a/src/Infrastructure/Data/ApplicationDbContextSeed.cs
+++ b/src/Infrastructure/Data/ApplicationDbContextSeed.cs
@@ -1,3 +1,4 @@
+using Hippo.Application.Common.Security;
 using Hippo.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity;
 
@@ -5,13 +6,25 @@ namespace Hippo.Infrastructure.Data;
 
 public static class ApplicationDbContextSeed
 {
-    public static async Task SeedIdentityRolesAsync(UserManager<Account> userManager, RoleManager<IdentityRole> roleManager)
+    public static async Task SeedIdentityRolesAsync(RoleManager<IdentityRole> roleManager)
     {
-        var administratorRole = new IdentityRole("Administrator");
+        var administratorRole = new IdentityRole(UserRole.Administrator);
 
         if (roleManager.Roles.All(r => r.Name != administratorRole.Name))
         {
             await roleManager.CreateAsync(administratorRole);
         }
+    }
+
+    public static async Task SeedAdministratorAccountsAsync(UserManager<Account> userManager, string username, string email, string password)
+    {
+        var user = new Account
+        {
+            UserName = username,
+            Email = email
+        };
+
+        await userManager.CreateAsync(user, password);
+        await userManager.AddToRoleAsync(user, UserRole.Administrator);
     }
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Hippo.Application.Common.Config;
 using Hippo.Application.Common.Interfaces;
+using Hippo.Application.Common.Security;
 using Hippo.Infrastructure.Data;
 using Hippo.Infrastructure.Exceptions;
 using Hippo.Infrastructure.Files;
@@ -72,7 +73,7 @@ public static class DependencyInjection
         services.AddTransient<IJsonFileBuilder, JsonFileBuilder>();
 
         services.AddAuthorization(options =>
-                options.AddPolicy("CanPurge", policy => policy.RequireRole("Administrator")));
+                options.AddPolicy(UserPolicy.CanPurge, policy => policy.RequireRole(UserRole.Administrator)));
 
         return services;
     }

--- a/src/Web/ClientApp/src/app/components/account/register/register.component.ts
+++ b/src/Web/ClientApp/src/app/components/account/register/register.component.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -58,8 +59,8 @@ export class RegisterComponent implements OnInit {
 					// TODO: navigate to registration confirmation page
 					next: () => this.router.navigate(['/']),
 					error: (err) => {
-						console.log(err.error.errors);
-						this.errors = this.parseError(err.error);
+						console.log(err);
+						this.errors = this.parseError(err);
 						this.loading = false;
 					}
 				}
@@ -67,11 +68,16 @@ export class RegisterComponent implements OnInit {
 	}
 
 	parseError(error: any) {
-		if (error.errors) {
-			return this.parseValidationErrors(error.errors);
-		} else {
-			return [error.title];
+		if (error.error)
+		{
+			var err = error.error;
+			if (err.errors) {
+				return this.parseValidationErrors(err.errors);
+			} else {
+				return [(err.detail) ? err.detail : `${err.status} - ${err.title}`]
+			}
 		}
+		return [(error.message) ? error.message : error.status ? `${error.status} - ${error.statusText}` : 'Server error'];
 	}
 
 	parseValidationErrors(error: any) {

--- a/src/Web/Filters/ApiExceptionFilterAttribute.cs
+++ b/src/Web/Filters/ApiExceptionFilterAttribute.cs
@@ -125,16 +125,19 @@ public class ApiExceptionFilterAttribute : ExceptionFilterAttribute
 
     private void HandleForbiddenAccessException(ExceptionContext context)
     {
+        var exception = (ForbiddenAccessException)context.Exception;
+
         var details = new ProblemDetails
         {
             Status = StatusCodes.Status403Forbidden,
             Title = "Forbidden",
-            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.3"
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.3",
+            Detail = exception.Message
         };
 
         context.Result = new ObjectResult(details)
         {
-            StatusCode = StatusCodes.Status403Forbidden
+            StatusCode = StatusCodes.Status403Forbidden,
         };
 
         context.ExceptionHandled = true;

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json.Serialization;
 using FluentValidation.AspNetCore;
 using Hippo.Application;
+using Hippo.Application.Common.Config;
 using Hippo.Application.Common.Interfaces;
 using Hippo.Infrastructure;
 using Hippo.Infrastructure.Data;
@@ -144,7 +145,15 @@ using (var scope = app.Services.CreateScope())
         var userManager = services.GetRequiredService<UserManager<Account>>();
         var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
 
-        await ApplicationDbContextSeed.SeedIdentityRolesAsync(userManager, roleManager);
+        await ApplicationDbContextSeed.SeedIdentityRolesAsync(roleManager);
+
+        HippoConfig hippoConfig = new HippoConfig();
+        builder.Configuration.GetSection("Hippo").Bind(hippoConfig);
+
+        foreach (var admin in hippoConfig.Administrators)
+        {
+            await ApplicationDbContextSeed.SeedAdministratorAccountsAsync(userManager, admin.Username, admin.Username, admin.Password);
+        }
     }
     catch (Exception ex)
     {

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -17,6 +17,9 @@
 		"Url": "http://localhost:4646/v1",
 		"Secret": ""
 	},
+	"Hippo": {
+		"RegistrationMode": "Closed"
+	},
 	"Database": {
 		"Driver": "postgresql"
 	},

--- a/tests/Core.UnitTests/Enums/RegistrationModeTests.cs
+++ b/tests/Core.UnitTests/Enums/RegistrationModeTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Hippo.Core.Enums;
+using Xunit;
+
+namespace Core.UnitTests.Enums;
+
+public class RegistrationModeTests
+{
+    /// <summary>
+    /// The underlying values here are contractual with the database.
+    /// **DO NOT** change the underlying numeric value of any case.
+    /// </summary>
+    [Fact]
+    public void ShouldReturnCorrectRegistrationMode()
+    {
+        Assert.Equal(0, (Convert.ToInt32(RegistrationMode.AdministratorOnly)));
+        Assert.Equal(1, (Convert.ToInt32(RegistrationMode.Closed)));
+        Assert.Equal(2, (Convert.ToInt32(RegistrationMode.Open)));
+
+        Assert.Equal("AdministratorOnly", RegistrationMode.AdministratorOnly.ToString());
+        Assert.Equal("Closed", RegistrationMode.Closed.ToString());
+        Assert.Equal("Open", RegistrationMode.Open.ToString());
+    }
+}

--- a/tests/Hippo.FunctionalTests/TestBase.cs
+++ b/tests/Hippo.FunctionalTests/TestBase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentValidation.AspNetCore;
 using Hippo.Application;
 using Hippo.Application.Common.Interfaces;
+using Hippo.Application.Common.Security;
 using Hippo.Application.Jobs;
 using Hippo.Core.Entities;
 using Hippo.Infrastructure;
@@ -114,7 +115,7 @@ public class TestBase : IDisposable
 
     public static async Task<string> RunAsAdministratorAsync()
     {
-        return await RunAsUserAsync("administrator@local", "Administrator1234!", new[] { "Administrator" });
+        return await RunAsUserAsync("administrator@local", "Administrator1234!", new[] { UserRole.Administrator });
     }
 
     public static async Task<string> RunAsUserAsync(string userName, string password, string[] roles)


### PR DESCRIPTION
These registration modes restrict who can register new accounts:

- "Open": open registration (the current default behaviour)
- "Closed": closed registration (no users can be registered)
- "AdministratorOnly": only Administrators can create new accounts

In addition, an initial list of administrators can be pre-seeded into the system by setting the "Hippo:Administrators:[(Username, Password)]" fields in appsettings.json.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>