### PR TITLE
fix: remove default registration mode setting to "Closed"

### DIFF
--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -17,9 +17,6 @@
 		"Url": "http://localhost:4646/v1",
 		"Secret": ""
 	},
-	"Hippo": {
-		"RegistrationMode": "Closed"
-	},
 	"Database": {
 		"Driver": "postgresql"
 	},


### PR DESCRIPTION
This was committed by accident while testing the various registration
modes.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>