### PR TITLE
Fix / Make sure domain is valid at initial channel creation

### DIFF
--- a/src/Web/ClientApp/src/app/components/application/new/new.component.ts
+++ b/src/Web/ClientApp/src/app/components/application/new/new.component.ts
@@ -97,7 +97,8 @@ export class NewComponent implements OnInit {
     this.appService.apiAppPost({ name: this.f['name'].value, storageId: this.f['storageId'].value })
     .subscribe({
       next: (appId) => {
-        this.channelService.apiChannelPost({ appId: appId, name: 'Production', revisionSelectionStrategy: ChannelRevisionSelectionStrategy.UseRangeRule, rangeRule: "*", domain: this.f['name'].value + '.' + window.location.hostname})
+        this.channelService.apiChannelPost({ appId: appId, name: 'Production', revisionSelectionStrategy: ChannelRevisionSelectionStrategy.UseRangeRule, rangeRule: "*", 
+            domain: `${this.f['name'].value}.${window.location.hostname}`.replace('_', '-').toLowerCase()})
           .subscribe({
             next: () => this.router.navigate(['/app']),
             error: (error) => {


### PR DESCRIPTION
Currently, if you are trying to create an application with a name that contains uppercase letters or underscores, the `CreateChannelCommandValidator` throws an error for the channel Domain property (as the url can't contain capitals or underscores).