### PR TITLE
improve nomad-dev script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,13 +16,13 @@
     ],
     "containerEnv": {
         "BINDLE_URL": "http://localhost:8080/v1",
-        "HIPPO_URL": "https://localhost:5309",
+        "HIPPO_URL": "http://localhost:5309",
         // This places bindle server data in the workspace so that state is retained across multiple invocations of the bindle server
         // Delete this folder and src/Web/hippo.db.* files to reset Hippo
         "BINDLE_DIRECTORY" : "${containerWorkspaceFolder}/bindleserver/data"
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // 5309 is the Hippo HTTPS port.
+    // 5309 is the Hippo HTTP port.
     // 8080 is the Bindle HTTP port.
     "forwardPorts": [
         5309,
@@ -34,8 +34,8 @@
     "postCreateCommand": "cd src/Web && dotnet restore && dotnet build && dotnet dev-certs https",
     "portsAttributes": {
         "5309": {
-            "label": "Hippo HTTPS Port",
-            "protocol": "https"
+            "label": "Hippo HTTP Port",
+            "protocol": "http"
         },
         "8080": {
             "label": "Bindle HTTP Port",

--- a/.github/release-image/Dockerfile
+++ b/.github/release-image/Dockerfile
@@ -71,13 +71,12 @@ ENV GLOBAL_AGENT_FORCE_GLOBAL_AGENT ${FORCE_GLOBAL_AGENT}
 
 # Docker/WSL2 has an issue exposing ports from localhost. the following tries to work around this issue.
 # See https://github.com/microsoft/WSL/issues/4983
-ARG HIPPO_HTTP_PORT="5308"
-ARG HIPPO_HTTPS_PORT="5309"
+ARG HIPPO_PORT="5309"
 
-ARG HIPPOURL=https://localhost:${HIPPO_HTTPS_PORT}
+ARG HIPPOURL=http://hippo.hippofactory.io:${HIPPO_PORT}
 ENV HIPPO_URL ${HIPPOURL}
 
-ENV ASPNETCORE_URLS http://0.0.0.0:${HIPPO_HTTP_PORT};https://0.0.0.0:${HIPPO_HTTPS_PORT}
+ENV ASPNETCORE_URLS http://0.0.0.0:${HIPPO_PORT}
 
 # Generate certs for hippo-server and proxy
 WORKDIR /data/certs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,4 +12,4 @@ Consul:  http://localhost:8500
 Nomad:   http://localhost:4646
 Traefik: http://localhost:8081
 Bindle:  http://bindle.hippofactory.io:8080
-Hippo:   https://hippo.hippofactory.io:5309
+Hippo:   http://hippo.hippofactory.io:5309

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,15 @@
+# Scripts
+
+Useful tools to help with Hippo development.
+
+## Running Locally
+
+```bash
+$ ./scripts/nomad-dev.sh
+```
+
+Consul:  http://localhost:8500
+Nomad:   http://localhost:4646
+Traefik: http://localhost:8081
+Bindle:  http://bindle.hippofactory.io:8080
+Hippo:   https://hippo.hippofactory.io:5309

--- a/scripts/nomad-dev.sh
+++ b/scripts/nomad-dev.sh
@@ -11,33 +11,58 @@ require() {
   fi
 }
 
+require dotnet
 require bindle-server
 require consul
 require nomad
 require spin
 require traefik
 
-trap 'kill $(jobs -p)' EXIT
+trap 'sudo kill $(jobs -p)' EXIT
 
 echo "Starting consul..."
 consul agent -dev -bootstrap-expect 1 -client '0.0.0.0' &>/tmp/consul.log &
 
 echo "Starting nomad..."
-nomad agent -dev &>/tmp/nomad.log &
+# NOTE(bacongobbler): nomad MUST run as root for the exec driver to work on Linux.
+# https://github.com/deislabs/hippo/blob/de73ae52d606c0a2351f90069e96acea831281bc/src/Infrastructure/Jobs/NomadJob.cs#L28
+# https://www.nomadproject.io/docs/drivers/exec#client-requirements
+if [[ "$OSTYPE" == "linux"* ]]
+then
+  sudo nomad agent -dev &>/tmp/nomad.log &
+else
+  nomad agent -dev &>/tmp/nomad.log &
+fi
+
+echo "Waiting for nomad..."
+while ! nomad server members 2>/dev/null | grep -q alive; do
+  sleep 1
+done
 
 echo "Starting traefik..."
-traefik --entryPoints.http.address=:8088 --providers.consulCatalog &>/tmp/traefik.log &
+sudo traefik --api.dashboard=true --api.insecure=true --entryPoints.http.address=:80 --entryPoints.traefik.address=:8081 --providers.consulCatalog &>/tmp/traefik.log &
 
 echo "Starting bindle..."
 bindle-server --unauthenticated &>/tmp/bindle.log &
 
-echo "Waiting for nomad..."
-while ! nomad server members 2>/dev/null | grep -q alive; do
-  sleep 2
-done
-
 echo "Starting hippo..."
-dotnet run --project src/Web \
-  --Hippo:PlatformDomain='127.0.0.1.sslip.io' &
+dotnet run --project src/Web &>/tmp/hippo.log &
+
+echo "Logs are available at:"
+echo
+echo "Consul: /tmp/consul.log"
+echo "Nomad: /tmp/nomad.log"
+echo "Traefik: /tmp/traefik.log"
+echo "Bindle: /tmp/bindle.log"
+echo "Hippo: /tmp/hippo.log"
+echo
+echo "Consul:  http://localhost:8500"
+echo "Nomad:   http://localhost:4646"
+echo "Traefik: http://localhost:8081"
+echo "Bindle:  http://bindle.hippofactory.io:8080"
+echo "Hippo:   https://hippo.hippofactory.io:5309"
+echo
+echo
+echo "Press CTRL+C to exit."
 
 wait

--- a/scripts/nomad-dev.sh
+++ b/scripts/nomad-dev.sh
@@ -60,7 +60,7 @@ echo "Consul:  http://localhost:8500"
 echo "Nomad:   http://localhost:4646"
 echo "Traefik: http://localhost:8081"
 echo "Bindle:  http://bindle.hippofactory.io:8080"
-echo "Hippo:   https://hippo.hippofactory.io:5309"
+echo "Hippo:   http://hippo.hippofactory.io:5309"
 echo
 echo
 echo "Press CTRL+C to exit."

--- a/src/Application/Common/Config/HippoConfig.cs
+++ b/src/Application/Common/Config/HippoConfig.cs
@@ -4,7 +4,7 @@ namespace Hippo.Application.Common.Config;
 
 public class HippoConfig
 {
-    public string PlatformDomain { get; set; } = "hippo.localdomain";
+    public string PlatformDomain { get; set; } = "hippofactory.io";
 
     public RegistrationMode RegistrationMode { get; set; } = RegistrationMode.Open;
 

--- a/src/Web/ClientApp/package.json
+++ b/src/Web/ClientApp/package.json
@@ -6,7 +6,7 @@
 		"publish": "ng build --configuration production",
 		"watch": "ng build --watch --configuration development",
 		"test": "ng test",
-		"generate:api": "JAVA_OPTS='-Dio.swagger.parser.util.RemoteUrl.trustAll=true -Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true' openapi-generator-cli generate -i https://localhost:5309/swagger/v1/swagger.json -g typescript-angular -o src/app/core/api/v1"
+		"generate:api": "JAVA_OPTS='-Dio.swagger.parser.util.RemoteUrl.trustAll=true -Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true' openapi-generator-cli generate -i http://localhost:5309/swagger/v1/swagger.json -g typescript-angular -o src/app/core/api/v1"
 	},
 	"private": true,
 	"dependencies": {

--- a/src/Web/ClientApp/proxy.conf.js
+++ b/src/Web/ClientApp/proxy.conf.js
@@ -1,7 +1,7 @@
 const { env } = require('process');
 
-const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
-  env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'https://localhost:5309';
+const target = env.ASPNETCORE_HTTP_PORT ? `https://localhost:${env.ASPNETCORE_HTTP_PORT}` :
+  env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'http://localhost:5309';
 
 const PROXY_CONFIG = [
   {

--- a/src/Web/ClientApp/src/app/components/channel/channel.component.html
+++ b/src/Web/ClientApp/src/app/components/channel/channel.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="channel && channel.appSummary" class="is-flex is-flex-direction-row is-align-items-center is-justify-content-space-between mb-6">
     <div>
         <h1 class="is-size-1">{{channel.appSummary.name}}</h1>
-        <a href="https://{{channel.domain}}" target="_blank">{{channel.domain}}</a>
+        <a href="{{protocol}}//{{channel.domain}}" target="_blank">{{channel.domain}}</a>
     </div>
     <div *ngIf="channel.appSummary.channels.length > 1 && activeTab != tabs.Settings">
         <div class="dropdown"

--- a/src/Web/ClientApp/src/app/components/channel/channel.component.ts
+++ b/src/Web/ClientApp/src/app/components/channel/channel.component.ts
@@ -17,6 +17,7 @@ export class ChannelComponent implements OnInit {
 	isSelectClicked: boolean = false;
 	tabs = ApplicationTabs;
 	activeTab = ApplicationTabs.Overview;
+	protocol = window.location.protocol;
 
 	constructor(
 		private route: ActivatedRoute,

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -94,8 +94,6 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
-app.UseHttpsRedirection();
-
 app.UseFileServer();
 
 app.UseRouting();
@@ -103,14 +101,8 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-// Configure the HTTP request pipeline.
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
-}
-else
+// enable swagger in development.
+if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/src/Web/Properties/launchSettings.json
+++ b/src/Web/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "",
-      "applicationUrl": "https://localhost:5309",
+      "applicationUrl": "http://localhost:5309",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -16,7 +16,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "",
-      "applicationUrl": "https://localhost:5309",
+      "applicationUrl": "http://localhost:5309",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"


### PR DESCRIPTION
- the default platform domain is now `hippofactory.io`, which contains a wildcard A record pointing to 127.0.0.1
- traefik now listens on both port 80 (http) and port 8081 (dashboard)
- nomad runs as root for `exec` support on linux
- traefik always runs as root so it can listen on port 80
- listens for HTTP requests by default; TLS should be terminated at the load balancer (Traefik)
- the UI now presents the same HTTP/HTTPS protocol for the channel domain