### PR TITLE
set fetch-depth to 0

### DIFF
--- a/.github/workflows/publish-devcontainer.yml
+++ b/.github/workflows/publish-devcontainer.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
https://github.com/adamralph/minver#why-is-the-default-version-sometimes-used-in-github-actions-and-travis-ci-when-a-version-tag-exists-in-the-history

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>