### PR TITLE
Bugfix 611 /  redirect to app list after creating app

### DIFF
--- a/src/Web/ClientApp/src/app/components/application/new/new.component.ts
+++ b/src/Web/ClientApp/src/app/components/application/new/new.component.ts
@@ -100,12 +100,12 @@ export class NewComponent implements OnInit {
         this.channelService.apiChannelPost({ appId: appId, name: 'Production', revisionSelectionStrategy: ChannelRevisionSelectionStrategy.UseRangeRule, rangeRule: "*", 
             domain: `${this.f['name'].value}.${window.location.hostname}`.replace('_', '-').toLowerCase()})
           .subscribe({
-            next: () => this.router.navigate(['/app']),
+            next: () => this.router.navigate(['/']),
             error: (error) => {
               console.log(error);
               this.error = (error.message) ? error.message : error.status ? `${error.status} - ${error.statusText}` : 'An error occurred while creating the channel';
               // we can still continue at this point; the user will just have to add a channel to the app.
-              this.router.navigate(['/app']);
+              this.router.navigate(['/']);
             }
           })
       },


### PR DESCRIPTION
The path to the app `ListComponent` defined in `app-routing.module.ts` is `/`.

Could not replicate the `/404` redirect after logging in, maybe it was fixed in a more recent Hippo version?