### PR TITLE
make channel overview link clickable

### DIFF
--- a/src/Web/ClientApp/src/app/components/channel/overview/overview.component.html
+++ b/src/Web/ClientApp/src/app/components/channel/overview/overview.component.html
@@ -17,8 +17,8 @@
 
     <div *ngIf="activeRevision">
         <div class="title is-size-5">Active revision components</div>
-        <div class="columns is-multiline mx-1">            
-            <div *ngFor="let component of activeRevision.components" 
+        <div class="columns is-multiline mx-1">
+            <div *ngFor="let component of activeRevision.components"
                 class="box has-text-centered column is-full-mobile is-half-tablet is-one-quarter-desktop"
             >
                 <div class="is-uppercase">{{component.type}}</div>
@@ -30,7 +30,7 @@
                 <div class="has-text-weight-bold is-size-4">{{component.name}}</div>
                 <div class="is-underlined">
                     <div *ngIf="component.type === types.HTTP">
-                        <a>{{component.route}}</a>
+                        <a href="{{protocol}}//{{channel.domain}}{{component.route}}" target="_blank">{{component.route}}</a>
                     </div>
                     <div *ngIf="component.type === types.Redis">{{component.channel}}</div>
                 </div>

--- a/src/Web/ClientApp/src/app/components/channel/overview/overview.component.ts
+++ b/src/Web/ClientApp/src/app/components/channel/overview/overview.component.ts
@@ -1,26 +1,34 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { ChannelService, RevisionDto } from 'src/app/core/api/v1';
+import { ChannelDto, ChannelService, RevisionDto } from 'src/app/core/api/v1';
 import { ComponentTypes } from 'src/app/_helpers/constants';
 import { faCheckCircle, faTimesCircle, faNetworkWired } from '@fortawesome/free-solid-svg-icons';
+import { Router } from '@angular/router';
 
 @Component({
-  selector: 'channel-overview',
-  templateUrl: './overview.component.html',
-  styleUrls: ['./overview.component.css']
+	selector: 'channel-overview',
+	templateUrl: './overview.component.html',
+	styleUrls: ['./overview.component.css']
 })
 export class OverviewComponent implements OnInit {
-  @Input() channelId = '';
-  activeRevision!: RevisionDto | undefined;
-  icons = { faCheckCircle, faTimesCircle, faNetworkWired };
-  types = ComponentTypes;
+	@Input() channelId = '';
+	channel!: ChannelDto;
+	activeRevision!: RevisionDto | undefined;
+	icons = { faCheckCircle, faTimesCircle, faNetworkWired };
+	types = ComponentTypes;
+	protocol = window.location.protocol;
 
-  constructor(private readonly channelService: ChannelService) { }
+	constructor(
+		private readonly channelService: ChannelService,
+		private router: Router) { }
 
-  ngOnInit(): void {
-    this.refreshData();
-  }
+	ngOnInit(): void {
+		this.refreshData();
+	}
 
-  refreshData() {
-		this.channelService.apiChannelChannelIdGet(this.channelId).subscribe(vm => (this.activeRevision = vm.activeRevision));
+	refreshData() {
+		this.channelService.apiChannelChannelIdGet(this.channelId).subscribe(channel => {
+			!channel ? this.router.navigate(['/404']) : this.channel = channel;
+			this.activeRevision = channel.activeRevision;
+		});
 	}
 }


### PR DESCRIPTION
This allows users to click on the HTTP component's route which will open a new page directly to the component.