### PR TITLE
nullable types are not required

### DIFF
--- a/src/Application/Apps/Queries/AppDto.cs
+++ b/src/Application/Apps/Queries/AppDto.cs
@@ -18,7 +18,6 @@ public class AppDto
     [Required]
     public string StorageId { get; set; } = "";
 
-    [Required]
     public string? Description { get; set; } = "";
 
     [Required]

--- a/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
@@ -13,6 +13,5 @@ public class RevisionComponent
     [Required]
     public string Description { get; set; } = string.Empty;
 
-    [Required]
     public RevisionComponentTrigger? Trigger { get; set; }
 }

--- a/src/Application/Common/Interfaces/BindleService/RevisionComponentTrigger.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionComponentTrigger.cs
@@ -4,9 +4,7 @@ namespace Hippo.Application.Common.Interfaces.BindleService;
 
 public class RevisionComponentTrigger
 {
-    [Required]
     public string? Route { get; set; }
 
-    [Required]
     public string? Channel { get; set; }
 }

--- a/src/Application/Common/Interfaces/BindleService/RevisionSpinToml.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionSpinToml.cs
@@ -4,7 +4,6 @@ namespace Hippo.Application.Common.Interfaces.BindleService;
 
 public class RevisionSpinToml
 {
-    [Required]
     public RevisionTrigger? Trigger { get; set; }
 
     [Required]

--- a/src/Application/Common/Interfaces/BindleService/RevisionTrigger.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionTrigger.cs
@@ -7,9 +7,7 @@ public class RevisionTrigger
     [Required]
     public string Type { get; set; } = string.Empty;
 
-    [Required]
     public string? Base { get; set; }
 
-    [Required]
     public string? Address { get; set; }
 }

--- a/src/Application/Revisions/Commands/UpdateRevisionDetailsCommand.cs
+++ b/src/Application/Revisions/Commands/UpdateRevisionDetailsCommand.cs
@@ -12,7 +12,6 @@ public class UpdateRevisionDetailsCommand : IRequest
     [Required]
     public Guid RevisionId { get; set; }
 
-    [Required]
     public RevisionDetails? RevisionDetails { get; set; }
 }
 

--- a/src/Application/Revisions/Queries/RevisionComponentDto.cs
+++ b/src/Application/Revisions/Queries/RevisionComponentDto.cs
@@ -14,12 +14,9 @@ public class RevisionComponentDto : IMapFrom<Core.Entities.RevisionComponent>
     [Required]
     public string Name { get; set; } = string.Empty;
 
-    [Required]
     public string? Route { get; set; }
 
-    [Required]
     public string? Channel { get; set; }
 
-    [Required]
     public string? Type { get; set; }
 }


### PR DESCRIPTION
This now generates the proper openapi spec for these types:

```
><> curl localhost:5309/swagger/v1/swagger.json -s | jq '.components.schemas.RevisionComponentDto'
{
  "required": [
    "id",
    "name",
    "source"
  ],
  "type": "object",
  "properties": {
    "id": {
      "type": "string",
      "format": "uuid"
    },
    "source": {
      "type": "string"
    },
    "name": {
      "type": "string"
    },
    "route": {
      "type": "string",
      "nullable": true
    },
    "channel": {
      "type": "string",
      "nullable": true
    },
    "type": {
      "type": "string",
      "nullable": true
    }
  },
  "additionalProperties": false
}
```