### PR TITLE
add other revision component fields

### DIFF
--- a/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
+++ b/src/Application/Common/Interfaces/BindleService/RevisionComponent.cs
@@ -4,14 +4,30 @@ namespace Hippo.Application.Common.Interfaces.BindleService;
 
 public class RevisionComponent
 {
+    /// The module source.
     [Required]
     public string Source { get; set; } = string.Empty;
 
+    /// ID of the component. Used at runtime to select between
+    /// multiple components of the same application.
     [Required]
     public string Id { get; set; } = string.Empty;
 
-    [Required]
-    public string Description { get; set; } = string.Empty;
+    /// Description of the component.
+    public string? Description { get; set; }
 
+    /// The parcel group to be mapped inside the Wasm module at runtime.
+    public string? Files { get; set; }
+
+    /// Optional list of HTTP hosts the component is allowed to connect.
+    public List<string>? AllowedHTTPHosts { get; set; }
+
+    /// Environment variables to be mapped inside the Wasm module at runtime.
+    public Dictionary<string, string>? Environment { get; set; }
+
+    /// Trigger configuration.
     public RevisionComponentTrigger? Trigger { get; set; }
+
+    /// Component-specific configuration values.
+    public Dictionary<string, string>? Config { get; set; }
 }


### PR DESCRIPTION
Fields like `files` are used for certain apps like Batholomew.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>