### PR TITLE
fix: Use NOMAD_ADDR_ instead of NOMAD_IP_ + NOMAD_PORT_

### DIFF
--- a/src/Infrastructure/Services/NomadJobService.cs
+++ b/src/Infrastructure/Services/NomadJobService.cs
@@ -182,7 +182,7 @@ public class NomadJobService : IJobService
             Config = new Dictionary<string, object>
             {
                 { "command", nomadJob.spinBinaryPath },
-                { "args", new List<string> { "up", "--listen", "${NOMAD_IP_http}:${NOMAD_PORT_http}", "--follow-all", "--bindle", nomadJob.BindleId } }
+                { "args", new List<string> { "up", "--listen", "${NOMAD_ADDR_http}", "--follow-all", "--bindle", nomadJob.BindleId } }
             }
         };
     }


### PR DESCRIPTION
In addition to being more concise, this may avoid issues with IPv6
addresses.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>