### PR TITLE
fix: get jobs that are valid GUIDs

### DIFF
--- a/src/Infrastructure/Services/NomadJobService.cs
+++ b/src/Infrastructure/Services/NomadJobService.cs
@@ -192,6 +192,7 @@ public class NomadJobService : IJobService
         try
         {
             var jobs = _jobsClient.GetJobs()
+                .Where(job => Guid.TryParse(job.ID, out _))
                 .Select(job => new NomadJob(_configuration, Guid.Parse(job.ID),
                     string.Empty,
                     string.Empty,


### PR DESCRIPTION
This ensures we retrieve a list of jobs that are valid GUIDs. Previously, if there were jobs named like "hippo", "traefik", or "bindle", GetJobs() would return null.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>