### PR TITLE
page fields must be required

### DIFF
--- a/src/Core/Models/Page.cs
+++ b/src/Core/Models/Page.cs
@@ -1,4 +1,6 @@
-﻿namespace Hippo.Core.Models;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Hippo.Core.Models;
 
 public class Page<TModel>
 {
@@ -15,30 +17,32 @@ public class Page<TModel>
     /// <summary>
     /// the fetched items
     /// </summary>
+    [Required]
     public IReadOnlyCollection<TModel> Items { get; set; } = new List<TModel>();
 
     /// <summary>
     /// the total number of items for the requested query
     /// </summary>
+    [Required]
     public int TotalItems { get; set; }
 
     /// <summary>
     /// The zero based page index of the current data
     /// </summary>
-    public int? PageIndex { get; set; }
+    [Required]
+    public int PageIndex { get; set; }
 
     /// <summary>
     /// The requested page size, not to be confused with the number of quered records
     /// </summary>
-    public int? PageSize { get; set; }
+    [Required]
+    public int PageSize { get; set; }
 
-    public bool? IsLastPage
+    [Required]
+    public bool IsLastPage
     {
         get
         {
-            if (!PageIndex.HasValue || !PageSize.HasValue)
-                return null;
-
             return TotalItems == PageIndex * PageSize + Items.Count;
         }
     }

--- a/src/Web/ClientApp/src/app/core/api/v1/model/appItemPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/appItemPage.ts
@@ -13,10 +13,10 @@ import { AppItem } from './appItem';
 
 
 export interface AppItemPage { 
-    items?: Array<AppItem> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<AppItem>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 

--- a/src/Web/ClientApp/src/app/core/api/v1/model/certificateItemPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/certificateItemPage.ts
@@ -13,10 +13,10 @@ import { CertificateItem } from './certificateItem';
 
 
 export interface CertificateItemPage { 
-    items?: Array<CertificateItem> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<CertificateItem>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 

--- a/src/Web/ClientApp/src/app/core/api/v1/model/channelItemPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/channelItemPage.ts
@@ -13,10 +13,10 @@ import { ChannelItem } from './channelItem';
 
 
 export interface ChannelItemPage { 
-    items?: Array<ChannelItem> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<ChannelItem>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 

--- a/src/Web/ClientApp/src/app/core/api/v1/model/channelJobStatusItemPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/channelJobStatusItemPage.ts
@@ -13,10 +13,10 @@ import { ChannelJobStatusItem } from './channelJobStatusItem';
 
 
 export interface ChannelJobStatusItemPage { 
-    items?: Array<ChannelJobStatusItem> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<ChannelJobStatusItem>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 

--- a/src/Web/ClientApp/src/app/core/api/v1/model/revisionItemPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/revisionItemPage.ts
@@ -13,10 +13,10 @@ import { RevisionItem } from './revisionItem';
 
 
 export interface RevisionItemPage { 
-    items?: Array<RevisionItem> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<RevisionItem>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 

--- a/src/Web/ClientApp/src/app/core/api/v1/model/stringPage.ts
+++ b/src/Web/ClientApp/src/app/core/api/v1/model/stringPage.ts
@@ -12,10 +12,10 @@
 
 
 export interface StringPage { 
-    items?: Array<string> | null;
-    totalItems?: number;
-    pageIndex?: number | null;
-    pageSize?: number | null;
-    readonly isLastPage?: boolean | null;
+    items: Array<string>;
+    totalItems: number;
+    pageIndex: number;
+    pageSize: number;
+    readonly isLastPage: boolean;
 }
 


### PR DESCRIPTION
The latest version of the OpenAPI spec states that these objects may be optional, forcing the SDKs like Rust and typescript to generate incorrect data types, breaking backwards compatibility.

https://github.com/fermyon/hippo-openapi/blob/db10524c7cbaa8fdf853e0c4264f4589981fb50b/clients/rust/src/models/app_item_page.rs#L17

This forces the OpenAPI generator to mark these fields as required so they are not marked as nullable.