### PR TITLE
bug: ensure login component only requires 6 character password minimum

### DIFF
--- a/src/Web/ClientApp/src/app/components/account/login/login.component.ts
+++ b/src/Web/ClientApp/src/app/components/account/login/login.component.ts
@@ -34,7 +34,7 @@ export class LoginComponent implements OnInit {
             username: new FormControl('', [Validators.required]),
             password: new FormControl('', [
                 Validators.required,
-                Validators.minLength(8),
+                Validators.minLength(6),
             ]),
         });
 


### PR DESCRIPTION
There is an inconsistency in hippo on the minimum required password length. While the hippo server [login component](https://github.com/deislabs/hippo/blob/main/src/Web/ClientApp/src/app/components/account/login/login.component.ts#L37 ) currently requires a minimum password length of 8, the [CreateAccoundCommandValidator](https://github.com/deislabs/hippo/blob/53757dbe1a3c197f3f429a1d62d2f37e4125f6f3/src/Application/Accounts/Commands/CreateAccountCommandValidator.cs#L25) and [register components](https://github.com/deislabs/hippo/blob/53757dbe1a3c197f3f429a1d62d2f37e4125f6f3/src/Web/ClientApp/src/app/components/account/register/register.component.html#L24) are checking for a min of 6 chars.

This makes them all consistent by having the login form also only require 6. 

fixes #1090

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>