### PR TITLE
Add `linux-arm64` target runtime to GitHub release workflow 

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,7 +38,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        target: ['linux-x64', 'win-x64', 'osx-x64']
+        target: ['linux-x64', 'win-x64', 'osx-x64', 'linux-arm64']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Following up to the [issue](https://github.com/deislabs/hippo/issues/1335) I filed, this changeset adds `linux/arm64` to the release workflow. I'm not sure if this is sufficient to update all the documentation so let me know if there is anything else I need to add.

Edit: Linking the issue #1335 