### PR TITLE
chore(*): bump spin and update usage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ ARG BINDLE_VERSION="v0.8.0"
 RUN curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server /usr/local/bin/
 
 # Install spin
-ARG SPIN_VERSION="v0.2.0"
+ARG SPIN_VERSION="v0.10.0"
 RUN curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin /usr/local/bin/
 
 # Install Rust

--- a/.github/release-image/Dockerfile
+++ b/.github/release-image/Dockerfile
@@ -43,8 +43,8 @@ ARG BINDLE_VERSION="v0.8.0"
 RUN mkdir bindle && cd bindle && curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server README.md LICENSE.txt /usr/local/bin/ && cd - && rm -r bindle
 
 # Install spin
-ARG SPIN_VERSION="v0.2.0"
-RUN mkdir spin && cd spin && curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin readme.md LICENSE /usr/local/bin/ && cd - && rm -r spin
+ARG SPIN_VERSION="v0.10.0"
+RUN mkdir spin && cd spin && curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin README.md LICENSE /usr/local/bin/ && cd - && rm -r spin
 
 # Install Rust
 RUN su ${USER} -c "mkdir rust && cd rust && curl -fsSLo install_rust.sh https://sh.rustup.rs && chmod +x ./install_rust.sh  && ./install_rust.sh -y -t wasm32-wasi && cd - && rm -r rust"

--- a/src/Infrastructure/Services/NomadJobService.cs
+++ b/src/Infrastructure/Services/NomadJobService.cs
@@ -191,7 +191,7 @@ public class NomadJobService : IJobService
             Config = new Dictionary<string, object>
             {
                 { "command", nomadJob.spinBinaryPath },
-                { "args", new List<string> { "up", "--listen", "${NOMAD_ADDR_http}", "--follow-all", "--bindle", nomadJob.BindleId } }
+                { "args", new List<string> { "up", "--listen", "${NOMAD_ADDR_http}", "--bindle", nomadJob.BindleId } }
             }
         };
     }


### PR DESCRIPTION
* Bump spin to [v0.10.0](https://github.com/fermyon/spin/releases/v0.10.0)
* In v0.10+, the `--follow-all` option for `spin up` is no longer valid; the behavior of that flag is now default (see linked release notes).

See also https://github.com/fermyon/installer/issues/126