### PR TITLE
chore(Dockerfile): bump spin to v0.10.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ ARG BINDLE_VERSION="v0.8.0"
 RUN curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server /usr/local/bin/
 
 # Install spin
-ARG SPIN_VERSION="v0.10.0"
+ARG SPIN_VERSION="v0.10.1"
 RUN curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin /usr/local/bin/
 
 # Install Rust

--- a/.github/release-image/Dockerfile
+++ b/.github/release-image/Dockerfile
@@ -43,7 +43,7 @@ ARG BINDLE_VERSION="v0.8.0"
 RUN mkdir bindle && cd bindle && curl -fsSLo bindle.tar.gz https://bindle.blob.core.windows.net/releases/bindle-${BINDLE_VERSION}-linux-amd64.tar.gz && tar -xvf bindle.tar.gz && mv bindle bindle-server README.md LICENSE.txt /usr/local/bin/ && cd - && rm -r bindle
 
 # Install spin
-ARG SPIN_VERSION="v0.10.0"
+ARG SPIN_VERSION="v0.10.1"
 RUN mkdir spin && cd spin && curl -fsSLo spin.tar.gz https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz  && tar -xvf spin.tar.gz && mv spin README.md LICENSE /usr/local/bin/ && cd - && rm -r spin
 
 # Install Rust


### PR DESCRIPTION
* Bump Spin to latest security patch: [v0.10.1](https://github.com/fermyon/spin/releases/tag/v0.10.1)

A follow-up to https://github.com/deislabs/hippo/pull/1482